### PR TITLE
V1.0 csprd01 issue214b

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -88,7 +88,7 @@ The name "OASIS" is a trademark of [OASIS](https://www.oasis-open.org/), the own
 -------
 
 # 1 Introduction
-OpenC2 is a suite of specifications that enables command and control of cyber defense systems and components.  OpenC2 typically uses a request-response paradigm where a command is encoded by an OpenC2 producer (managing application) and transferred to an OpenC2 consumer (managed device or virtualized function) using a secure transfer protocol. The consumer can respond with status and any requested information.  The contents of both the command and the response are fully defined in schemas, allowing both parties to recognize the syntax constraints imposed on the exchange.
+OpenC2 is a suite of specifications that enables command and control of cyber defense systems and components.  OpenC2 typically uses a request-response paradigm where a Command is encoded by a _Producer_ (managing application) and transferred to a _Consumer_ (managed device or virtualized function) using a secure transfer protocol. The Consumer can respond with status and any requested information.  The contents of both the _Command_ and the _Response_ are fully defined in schemas, allowing both parties to recognize the syntax constraints imposed on the exchange.
 
 OpenC2 allows the application producing the commands to discover the set of capabilities supported by the managed devices.  These capabilities permit the managing application to adjust its behavior to take advantage of the features exposed by the managed device.  The capability definitions can be easily extended in a noncentralized manner, allowing standard and non-standard capabilities to be defined with semantic and syntactic rigor.
 
@@ -98,11 +98,11 @@ This specification is provided under the [Non-Assertion](https://www.oasis-open.
 ## 1.2 Terminology
 * **Action**: The task or activity to be performed.
 * **Actuator**: The entity that performs the action.
-* **Command**: A message defined by an action-target pair that is sent from a producer and received by a consumer.
-* **Consumer**: A managed device / application that receives commands.  Note that a single device / application can have both consumer and producer capabilities.
-* **Producer**: A manager application that sends commands.
-* **Response**: A message from a consumer to a producer acknowledging a command or returning the requested resources or status to a previously received request.
-* **Target**: The object of the action, i.e., the action is performed on the target.
+* **Command**: A message defined by an action-target pair that is sent from a Producer and received by a Consumer.
+* **Consumer**: A managed device / application that receives Commands.  Note that a single device / application can have both Consumer and Producer capabilities.
+* **Producer**: A manager application that sends Commands.
+* **Response**: A message from a Consumer to a Producer acknowledging a Command or returning the requested resources or status to a previously received request.
+* **Target**: The object of the Action, i.e., the Action is performed on the Target.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [[RFC2119](#rfc2119)] and [[RFC8174](#rfc8174)].
 
@@ -189,23 +189,23 @@ Example:
 ```
 
 ## 1.6 Overview
-OpenC2 is a suite of specifications to command actuators that execute cyber defense functions in an unambiguous, standardized way.  These specifications include the OpenC2 Language Specification, Actuator Profiles, and Transfer Specifications.  The OpenC2 Language Specification and Actuator Profile specifications focus on the standard at the producer and consumer of the command and response while the transfer specifications focus on the protocols for their exchange.
+OpenC2 is a suite of specifications to command actuators that execute cyber defense functions in an unambiguous, standardized way.  These specifications include the OpenC2 Language Specification, Actuator Profiles, and Transfer Specifications.  The OpenC2 Language Specification and Actuator Profile specifications focus on the standard at the Producer and Consumer of the Command and Response while the transfer specifications focus on the protocols for their exchange.
 
-* The OpenC2 Language Specification provides the semantics for the essential elements of the language, the structure for commands and responses, and the schema that defines the proper syntax for the language elements that represents the command or response.
-* OpenC2 Actuator Profiles specify the subset of the OpenC2 language relevant in the context of specific actuator functions. Cyber defense components, devices, systems and/or instances may (in fact are likely) to implement multiple actuator profiles.  Actuator profiles extend the language by defining specifiers that identify the actuator to the required level of precision and may define command arguments that are relevant and/or unique to those actuator functions.
+* The OpenC2 Language Specification provides the semantics for the essential elements of the language, the structure for Commands and Responses, and the schema that defines the proper syntax for the language elements that represents the Command or Response.
+* OpenC2 Actuator Profiles specify the subset of the OpenC2 language relevant in the context of specific Actuator functions. Cyber defense components, devices, systems and/or instances may (in fact are likely) to implement multiple Actuator profiles.  Actuator profiles extend the language by defining specifiers that identify the Actuator to the required level of precision and may define command arguments that are relevant and/or unique to those Actuator functions.
 * OpenC2 Transfer Specifications utilize existing protocols and standards to implement OpenC2 in specific environments. These standards are used for communications and security functions beyond the scope of the language, such as message transfer encoding, authentication, and end-to-end transfer of OpenC2 messages.
 
-The OpenC2 Language Specification defines a language used to compose messages for command and control of cyber defense systems and components.  A message consists of a header and a payload (_defined_ as a message body in the OpenC2 Language Specification Version 1.0 and _specified_ in one or more actuator profiles). 
+The OpenC2 Language Specification defines a language used to compose messages for command and control of cyber defense systems and components.  A message consists of a header and a payload (_defined_ as a message body in the OpenC2 Language Specification Version 1.0 and _specified_ in one or more Actuator profiles). 
 
 In general, there are two types of participants involved in the exchange of OpenC2 messages, as depicted in Figure 1-1:
 
-1. **OpenC2 Producers**: An OpenC2 Producer is an entity that creates commands to provide instruction to one or more systems to act in accordance with the content of the command. An OpenC2 Producer may receive and process responses in conjunction with a command.
-2. **OpenC2 Consumers**: An OpenC2 Consumer is an entity that receives and may act upon an OpenC2 command.  An OpenC2 Consumer may create responses that provide any information captured or necessary to send back to the OpenC2 Producer. 
+1. **Producer**: A Producer is an entity that creates Commands to provide instruction to one or more systems to act in accordance with the content of the Command. A Producer may receive and process Responses in conjunction with a Command.
+2. **Consumer**: A Consumer is an entity that receives and may act upon a Command.  A Consumer may create Responses that provide any information captured or necessary to send back to the Producer. 
 
 The language defines two payload structures:
 
-1. **Command**: An instruction from one system known as the OpenC2 "Producer", to one or more systems, the OpenC2 "Consumer(s)", to act on the content of the command.
-2. **Response**: Any information captured or necessary to send back to the OpenC2 Producer  that issued the Command, i.e., the OpenC2 Consumer’s response to the OpenC2 Producer.
+1. **Command**: An instruction from one system known as the Producer, to one or more systems, the Consumer(s), to act on the content of the Command.
+2. **Response**: Any information captured or necessary to send back to the Producer that issued the Command, i.e., the Consumer’s Response to the Producer.
 
 ![no alt title](images/image_1.png)
 
@@ -228,10 +228,10 @@ OpenC2 is conceptually partitioned into four layers as shown in Table 1-1.
 | Message | Transfer Specifications<br>(OpenC2-over-HTTPS, OpenC2-over-CoAP, …) |
 | Secure Transfer | HTTPS, CoAP, MQTT, OpenDXL, ... |
 
-* The **Secure Transfer** layer provides a communication path between the producer and the consumer.  OpenC2 can be layered over any standard transfer protocol.
+* The **Secure Transfer** layer provides a communication path between the Producer and the Consumer.  OpenC2 can be layered over any standard transfer protocol.
 * The **Message** layer provides a transfer- and content-independent mechanism for conveying requests, responses, and notifications.  A transfer specification maps transfer-specific protocol elements to a transfer-independent set of message elements consisting of content and associated metadata.  
-* The **Common Content** layer defines the structure of OpenC2 commands and responses and a set of common language elements used to construct them.
-* The **Function-specific Content** layer defines the language elements used to support a particular cyber defense function.  An actuator profile defines the implementation conformance requirements for that function.  OpenC2 Producers and Consumers will support one or more profiles.
+* The **Common Content** layer defines the structure of Commands and Responses and a set of common language elements used to construct them.
+* The **Function-specific Content** layer defines the language elements used to support a particular cyber defense function.  An Actuator profile defines the implementation conformance requirements for that function. Producers and Consumers will support one or more profiles.
 
 ## 1.7 Goal
 The goal of the OpenC2 Language Specification is to provide a language for interoperating between functional elements of cyber defense systems. This language used in conjunction with OpenC2 Actuator Profiles and OpenC2 Transfer Specifications allows for vendor-agnostic cybertime response to attacks.
@@ -246,64 +246,64 @@ The Integrated Adaptive Cyber Defense (IACD) framework defines a collection of a
 The goal of OpenC2 is to enable coordinated defense in cyber-relevant time between decoupled blocks that perform cyber defense functions.  OpenC2 focuses on the Acting portion of the IACD framework; the assumption that underlies the design of OpenC2 is that the sensing/ analytics have been provisioned and the decision to act has been made. This goal and these assumptions guides the design of OpenC2:
 
 * **Technology Agnostic:**  The OpenC2 language defines a set of abstract atomic cyber defense actions in a platform and product agnostic manner
-* **Concise:**  An OpenC2 command is intended to convey only the essential information required to describe the action required and can be represented in a very compact form for communications-constrained environments
-* **Abstract:**  OpenC2 commands and responses are defined abstractly and can be encoded and transferred via multiple schemes as dictated by the needs of different implementation environments
-* **Extensible:**  While OpenC2 defines a core set of actions and targets for cyber defense, the language is expected to evolve with cyber defense technologies, and permits extensions to accommodate new cyber defense technologies.
+* **Concise:**  A Command is intended to convey only the essential information required to describe the action required and can be represented in a very compact form for communications-constrained environments
+* **Abstract:**  Commands and Responses are defined abstractly and can be encoded and transferred via multiple schemes as dictated by the needs of different implementation environments
+* **Extensible:**  While OpenC2 defines a core set of Actions and Targets for cyber defense, the language is expected to evolve with cyber defense technologies, and permits extensions to accommodate new cyber defense technologies.
 
 ## 1.8 Purpose and Scope
 The OpenC2 Language Specification defines the set of components to assemble a complete command and control message and provides a framework so that the language can be extended. To achieve this purpose, the scope of this specification includes:
 
-1. the set of actions and options that may be used in OpenC2 commands
-2. the set of targets and target specifiers
-3. a syntax that defines the structure of commands and responses
-4. a JSON serialization of OpenC2 commands and responses
+1. the set of Actions and options that may be used in Commands
+2. the set of Targets and Target specifiers
+3. a syntax that defines the structure of Commands and Responses
+4. a JSON serialization of Commands and Responses
 5. the procedures for extending the language
 
-The OpenC2 language assumes that the event has been detected, a decision to act has been made, the act is warranted, and the initiator and recipient of the commands are authenticated and authorized. The OpenC2 language was designed to be agnostic of the other aspects of cyber defense implementations that realize these assumptions. The following items are beyond the scope of this specification:
+The OpenC2 language assumes that the event has been detected, a decision to act has been made, the act is warranted, and the initiator and recipient of the Commands are authenticated and authorized. The OpenC2 language was designed to be agnostic of the other aspects of cyber defense implementations that realize these assumptions. The following items are beyond the scope of this specification:
 
-1. Language extensions applicable to some actuators, which may be defined in individual actuator profiles.
-2. Alternate serializations of OpenC2 commands and responses.
+1. Language extensions applicable to some Actuators, which may be defined in individual Actuator profiles.
+2. Alternate serializations of Commands and Responses.
 3. The enumeration of the protocols required for transport, information assurance, sensing, analytics and other external dependencies.
 
 -------
 
 # 2 OpenC2 Language Description
-The OpenC2 language has two distinct content types: command and response. The command is sent from a producer to a consumer and describes an action to be performed by an actuator on a target. The response is sent from a consumer, usually back to the producer, and is a means to provide information (such as acknowledgement, status, etc.) as a result of a command.
+The OpenC2 language has two distinct content types: Command and Response. The Command is sent from a Producer to a Consumer and describes an Action to be performed by an Actuator on a Target. The Response is sent from a Consumer, usually back to the Producer, and is a means to provide information (such as acknowledgement, status, etc.) as a result of a Command.
 
 ## 2.1 OpenC2 Command
-The command describes an action to be performed on a target and may include information identifying the actuator or actuators that are to execute the command. 
+The Command describes an Action to be performed on a Target and may include information identifying the Actuator or Actuators that are to execute the Command. 
 
-A command has four main components: ACTION, TARGET, ARGUMENTS, and ACTUATOR. The following list summarizes the components of a command. 
+A Command has four main components: ACTION, TARGET, ARGUMENTS, and ACTUATOR. The following list summarizes the components of a Command. 
 
 * **ACTION** (required): The task or activity to be performed.
-* **TARGET** (required): The object of the action. The ACTION is performed on the target.
-    * **TARGET-NAME** (required): The name of the object of the action.
-    * **TARGET-SPECIFIERS** (optional): The specifier further identifies the target to some level of precision, such as a specific target, a list of targets, or a class of targets.
-* **ARGUMENTS** (optional): Provide additional information on how the command is to be performed, such as date/time, periodicity, duration etc.
-* **ACTUATOR** (optional): The ACTUATOR executes the command (the ACTION and TARGET). The ACTUATOR type will be defined within the context of an Actuator Profile.
-    * **ACTUATOR-NAME** (required): The name of the set of functions (e.g., "slpf") performed by the actuator, and the name of the profile defining commands applicable to those functions.
-    * **ACTUATOR-SPECIFIERS** (optional): The specifier identifies the actuator to some level of precision, such as a specific actuator, a list of actuators, or a group of actuators.
+* **TARGET** (required): The object of the Action. The ACTION is performed on the Target.
+    * **TARGET-NAME** (required): The name of the object of the Action.
+    * **TARGET-SPECIFIERS** (optional): The specifier further identifies the Target to some level of precision, such as a specific Target, a list of Targets, or a class of Targets.
+* **ARGUMENTS** (optional): Provide additional information on how the Command is to be performed, such as date/time, periodicity, duration etc.
+* **ACTUATOR** (optional): The ACTUATOR executes the Command (the ACTION and TARGET). The ACTUATOR type will be defined within the context of an Actuator Profile.
+    * **ACTUATOR-NAME** (required): The name of the set of functions (e.g., "slpf") performed by the Actuator, and the name of the profile defining Commands applicable to those functions.
+    * **ACTUATOR-SPECIFIERS** (optional): The specifier identifies the Actuator to some level of precision, such as a specific Actuator, a list of Actuators, or a group of Actuators.
 
-The ACTION and TARGET components are required and are populated by one of the actions in [Section 3.3.1.1](#3311-action) and the targets in [Section 3.3.1.2](#3312-target). A particular target may be further refined by one or more TARGET-SPECIFIERS. Procedures to extend the targets are described in [Section 3.3.4](#334-extensions).
+The ACTION and TARGET components are required and are populated by one of the Actions in [Section 3.3.1.1](#3311-action) and the Targets in [Section 3.3.1.2](#3312-target). A particular Target may be further refined by one or more TARGET-SPECIFIERS. Procedures to extend the Targets are described in [Section 3.3.4](#334-extensions).
 
-TARGET-SPECIFIERS provide additional precision to identify the target (e.g., 10.1.2.3) and may include a method of identifying multiple targets of the same type (e.g., 10.1.0.0/16).
+TARGET-SPECIFIERS provide additional precision to identify the Target (e.g., 10.1.2.3) and may include a method of identifying multiple Targets of the same type (e.g., 10.1.0.0/16).
 
-The ARGUMENTS component, if present, is populated by one or more 'command arguments' that determine how the command is executed. ARGUMENTS influence the command by providing information such as time, periodicity, duration, or other details on what is to be executed. They can also be used to convey the need for acknowledgement or additional status information about the execution of a command. The valid ARGUMENTS defined in this specification are in [Section 3.3.1.4](#3314-command-arguments).
+The ARGUMENTS component, if present, is populated by one or more 'command arguments' that determine how the Command is executed. ARGUMENTS influence the Command by providing information such as time, periodicity, duration, or other details on what is to be executed. They can also be used to convey the need for acknowledgement or additional status information about the execution of a Command. The valid ARGUMENTS defined in this specification are in [Section 3.3.1.4](#3314-command-arguments).
 
-An ACTUATOR is an implementation of a cyber defense function that executes the command. An Actuator Profile is a specification that identifies the subset of ACTIONS, TARGETS and other aspects of this language specification that are mandatory to implement or optional in the context of a particular ACTUATOR. An Actuator Profile may extend the language by defining additional ARGUMENTS, ACTUATOR-SPECIFIERS, and/or TARGETS that are meaningful and possibly unique to the actuator.
+An ACTUATOR is an implementation of a cyber defense function that executes the Command. An Actuator Profile is a specification that identifies the subset of ACTIONS, TARGETS and other aspects of this language specification that are mandatory to implement or optional in the context of a particular ACTUATOR. An Actuator Profile may extend the language by defining additional ARGUMENTS, ACTUATOR-SPECIFIERS, and/or TARGETS that are meaningful and possibly unique to the Actuator.
 
-The ACTUATOR optionally identifies the entity or entities that are tasked to execute the command. Specifiers for actuators refine the command so that a particular function, system, class of devices, or specific device can be identified. 
+The ACTUATOR optionally identifies the entity or entities that are tasked to execute the Command. Specifiers for Actuators refine the Command so that a particular function, system, class of devices, or specific device can be identified. 
 
-The ACTUATOR component may be omitted from a command and typically will not be included in implementations where the identities of the endpoints are unambiguous or when a high-level effects-based command is desired and the tactical decisions on how the effect is achieved is left to the recipient.  
+The ACTUATOR component may be omitted from a Command and typically will not be included in implementations where the identities of the endpoints are unambiguous or when a high-level effects-based Command is desired and the tactical decisions on how the effect is achieved is left to the recipient.  
 
 ## 2.2 OpenC2 Response
-The OpenC2 Response is a message sent from the recipient of a command. Response messages provide acknowledgement, status, results from a query, or other information.
+The Response is a message sent from the recipient of a Command. Response messages provide acknowledgement, status, results from a query, or other information.
 
-The following list summarizes the fields and subfields of an OpenC2 Response. 
+The following list summarizes the fields and subfields of a Response. 
 
 * **STATUS** (required): An integer containing a numerical status code
-* **STATUS_TEXT** (optional): A free-form string containing human-readable description of the response status. The string can contain more detail than is represented by the status code, but does not affect the meaning of the response.
-* **RESULTS** (optional): Contains the data or extended status code that was requested from an OpenC2 Command. 
+* **STATUS_TEXT** (optional): A free-form string containing human-readable description of the Response status. The string can contain more detail than is represented by the status code, but does not affect the meaning of the Response.
+* **RESULTS** (optional): Contains the data or extended status code that was requested from a Command. 
 
 -------
 
@@ -368,7 +368,7 @@ An Enumerated field may be derived ("auto-generated") from the fields of a Choic
 | 1 | targets | Target.* | 1..n | Enumeration auto-generated from a Choice |
 
 ### 3.1.5 Serialization
-OpenC2 is agnostic of any particular serialization; however, OpenC2 Consumers MUST support JSON serialization in accordance with RFC 7493 and additional requirements specified in the following table.
+OpenC2 is agnostic of any particular serialization; however, Consumers MUST support JSON serialization in accordance with RFC 7493 and additional requirements specified in the following table.
 
 **JSON Serialization Requirements:**
 
@@ -402,9 +402,9 @@ For machine-to-machine serialization formats, integers are represented as binary
 The default representation of Integer types in text serializations is the native integer type for that format, e.g., "number" for JSON.   Integer fields with a range larger than the IEEE 754 exact range (e.g., 64, 128, 2048 bit values) are indicated by appending ".<bit-size>" or ".*" to the type, e.g. Integer.64 or Integer.*.  All serializations ensure that large Integer types are transferred exactly, for example in the same manner as Binary types.  Integer values support arithmetic operations; Binary values are not intended for that purpose.
 
 ## 3.2 Message
-As described in Section 1.1, this language specification and one or more actuator profiles define the content of OpenC2 commands and responses, while transfer specifications define the on-the-wire format of a message over specific secure transport protocols.  Transfer specifications are agnostic with regard to content, and content is agnostic with regard to transfer protocol.  This decoupling is accomplished by defining a standard message interface used to transfer any type of content over any transfer protocol.
+As described in Section 1.1, this language specification and one or more Actuator profiles define the content of Commands and Responses, while transfer specifications define the on-the-wire format of a message over specific secure transport protocols.  Transfer specifications are agnostic with regard to content, and content is agnostic with regard to transfer protocol.  This decoupling is accomplished by defining a standard message interface used to transfer any type of content over any transfer protocol.
 
-A message is a content- and transport-independent set of elements conveyed between consumers and producers.  To ensure interoperability all transfer specifications must unambiguously define how the message elements in [Table 3-1](#table-3-1-common-message-elements) are represented within the secure transport protocol. This does not imply that all message elements must be used in all messages.  Content, content_type, and msg_type are required, while other message elements are not required by this specification but may be required by other documents.
+A message is a content- and transport-independent set of elements conveyed between Consumers and Producers.  To ensure interoperability all transfer specifications must unambiguously define how the message elements in [Table 3-1](#table-3-1-common-message-elements) are represented within the secure transport protocol. This does not imply that all message elements must be used in all messages.  Content, content_type, and msg_type are required, while other message elements are not required by this specification but may be required by other documents.
 
 ###### Table 3-1. Common Message Elements
 
@@ -412,9 +412,9 @@ A message is a content- and transport-independent set of elements conveyed betwe
 | :--- | :--- |
 | **content** | Message body as specified by content_type and msg_type. |
 | **content_type** | String. Media Type that identifies the format of the content, including major version. Incompatible content formats must have different content_types.  Content_type **application/openc2** identifies content defined by OpenC2 language specification versions 1.x, i.e., all versions that are compatible with version 1.0. |
-| **msg_type** | Message-Type. One of **request**, **response**, or **notification**.  For the **application/openc2** content_type the request content is an OpenC2-Command and the response content is an OpenC2-Response.  OpenC2 does not currently define any notification content. |
-| **status** | Status-Code.  Populated with a numeric status code in response messages.  Not present in request or notification messages. |
-| **request_id** | Request-Id. A unique identifier value of up to 128 bits that is attached to request and response messages. This value is assigned by the sender and is copied unmodified into all responses to support  reference to a particular command, transaction or event chain. |
+| **msg_type** | Message-Type. One of **request**, **response**, or **notification**.  For the **application/openc2** content_type the request content is an OpenC2-Command and the Response content is an OpenC2-Response.  OpenC2 does not currently define any notification content. |
+| **status** | Status-Code.  Populated with a numeric status code in Response messages.  Not present in request or notification messages. |
+| **request_id** | Request-Id. A unique identifier value of up to 128 bits that is attached to request and Response messages. This value is assigned by the sender and is copied unmodified into all Responses to support  reference to a particular Command, transaction or event chain. |
 | **created** | Date-Time. Creation date/time of the content, the number of milliseconds since 00:00:00 UTC, 1 January 1970. |
 | **from** | String. Authenticated identifier of the creator of or authority for execution of a message. |
 | **to** | ArrayOf(String). Authenticated identifier(s) of the authorized recipient(s) of a message. |
@@ -422,21 +422,21 @@ A message is a content- and transport-independent set of elements conveyed betwe
 Implementations may use environment variables, private APIs, data structures, class instances, pointers, or other mechanisms to represent messages within the local environment.  However the internal representation of a message does not affect interoperability and is therefore beyond the scope of OpenC2.  This means that the message content is a data structure in whatever form is used within an implementation, not a serialized representation of that structure.  Content is the input provided to a serializer or the output of a de-serializer.  Msg_type is a three-element enumeration whose protocol representation is defined in each transfer spec, for example as a string, an integer, or a two-bit field.  The internal form of enumerations, like content, does not affect interoperability and is therefore unspecified.
 
 ## 3.3 Content
-The scope of this specification is to define the ACTION and TARGET portions of an OpenC2 command and the common portions of an OpenC2 response.  The properties of the OpenC2 command are defined in [Section 3.3.1](#331-openc2-command) and the properties of the response are defined in [Section 3.3.2](#332-openc2-response).
+The scope of this specification is to define the ACTION and TARGET portions of a Command and the common portions of a Response.  The properties of the Command are defined in [Section 3.3.1](#331-openc2-command) and the properties of the Response are defined in [Section 3.3.2](#332-openc2-response).
 
-In addition to the ACTION and TARGET, an OpenC2 command has an optional ACTUATOR. Other than identification of namespace identifier, the semantics associated with the ACTUATOR specifiers are beyond the scope of this specification.  The actuators and actuator-specific results contained in a response are specified in ‘Actuator Profile Specifications’ such as StateLess Packet Filtering Profile, Routing Profile etc.
+In addition to the ACTION and TARGET, a Command has an optional ACTUATOR. Other than identification of namespace identifier, the semantics associated with the ACTUATOR specifiers are beyond the scope of this specification.  The Actuators and Actuator-specific results contained in a Response are specified in ‘Actuator Profile Specifications’ such as StateLess Packet Filtering Profile, Routing Profile etc.
 
 ### 3.3.1 OpenC2 Command
-The OpenC2 Command describes an action performed on a target. 
+The Command describes an Action performed on a Target. 
 
 **_Type: OpenC2-Command (Record)_**
 
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | **action** | Action | 1 | The task or activity to be performed (i.e., the 'verb'). |
-| 2 | **target** | Target | 1 | The object of the action. The action is performed on the target. |
-| 3 | **args** | Args | 0..1 | Additional information that applies to the command. |
-| 4 | **actuator** | Actuator | 0..1 | The subject of the action. The actuator executes the action on the target. |
+| 2 | **target** | Target | 1 | The object of the Action. The Action is performed on the Target. |
+| 3 | **args** | Args | 0..1 | Additional information that applies to the Command. |
+| 4 | **actuator** | Actuator | 0..1 | The subject of the Action. The Actuator executes the Action on the Target. |
 
 #### 3.3.1.1 Action
 **_Type: Action (Enumerated)_**
@@ -448,40 +448,40 @@ The OpenC2 Command describes an action performed on a target.
 | 3 | **query** | Initiate a request for information. |
 | 6 | **deny** | Prevent a certain event or action from completion, such as preventing a flow from reaching a destination or preventing access. |
 | 7 | **contain** | Isolate a file, process, or entity so that it cannot modify or access assets or processes. |
-| 8 | **allow** | Permit access to or execution of a target. |
+| 8 | **allow** | Permit access to or execution of a Target. |
 | 9 | **start** | Initiate a process, application, system, or activity. |
 | 10 | **stop** | Halt a system or end an activity. |
 | 11 | **restart** | Stop then start a system or an activity. |
-| 14 | **cancel** | Invalidate a previously issued action. |
+| 14 | **cancel** | Invalidate a previously issued Action. |
 | 15 | **set** | Change a value, configuration, or state of a managed entity. |
 | 16 | **update** | Instruct a component to retrieve, install, process, and operate in accordance with a software update, reconfiguration, or other update. |
 | 18 | **redirect** | Change the flow of traffic to a destination other than its original destination. |
 | 19 | **create** | Add a new entity of a known type (e.g., data, files, directories). |
 | 20 | **delete** | Remove an entity (e.g., data, files, flows). |
-| 22 | **detonate** | Execute and observe the behavior of a target (e.g., file, hyperlink) in an isolated environment. |
+| 22 | **detonate** | Execute and observe the behavior of a Target (e.g., file, hyperlink) in an isolated environment. |
 | 23 | **restore** | Return a system to a previously known state. |
 | 28 | **copy** | Duplicate an object,  file, data flow or artifact. |
 | 30 | **investigate** | Task the recipient to aggregate and report information as it pertains to a security event or incident. |
 | 32 | **remediate** | Task the recipient to eliminate a vulnerability or attack point. |
 
-The following actions are under consideration for use in future versions of the Language Specification. Implementers may use these actions with the understanding that they may not be in future versions of the language.
+The following Actions are under consideration for use in future versions of the Language Specification. Implementers may use these Actions with the understanding that they may not be in future versions of the language.
 
 * **report** - Task an entity to provide information to a designated recipient
 * **pause** - Cease operation of a system or activity while maintaining state.
 * **resume** - Start a system or activity from a paused state
 * **move** - Change the location of a file, subnet, network, or process
-* **snapshot** - Record and store the state of a target at an instant in time
+* **snapshot** - Record and store the state of a Target at an instant in time
 * **save** - Commit data or system state to memory
 * **throttle** - Adjust the rate of a process, function, or activity
 * **delay** - Stop or hold up an activity or data transmittal
 * **substitute** - Replace all or part of the payload
-* **sync** - Synchronize a sensor or actuator with other system components
+* **sync** - Synchronize a sensor or Actuator with other system components
 * **mitigate** -  Task the recipient to circumvent a problem without necessarily eliminating the vulnerability or attack point
 
 **Usage Requirements:**
 
-* Each command MUST contain exactly one action. 
-* All commands MUST only use actions from this section (either the table or the list) 
+* Each Command MUST contain exactly one Action. 
+* All Commands MUST only use Actions from this section (either the table or the list) 
 * Actions defined external to this section SHALL NOT be used.
 
 #### 3.3.1.2 Target
@@ -490,23 +490,23 @@ The following actions are under consideration for use in future versions of the 
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | **artifact** | Artifact | 1 | An array of bytes representing a file-like object or a link to that object. |
-| 2 | **command** | Request-Id | 1 | A reference to a previously issued OpenC2 Command. |
+| 2 | **command** | Request-Id | 1 | A reference to a previously issued Command. |
 | 3 | **device** | Device | 1 | The properties of a hardware device. |
 | 7 | **domain_name** | Domain-Name | 1 | A network domain name. |
 | 8 | **email_addr** | Email-Addr | 1 | A single email address. |
-| 16 | **features** | Features | 1 | A set of items used with the query action to determine an actuator's capabilities. |
+| 16 | **features** | Features | 1 | A set of items used with the query Action to determine an Actuator's capabilities. |
 | 10 | **file** | File | 1 | Properties of a file. |
 | 11 | **ip_addr** | IP-Addr | 1 | An IP address (either version 4 or version 6). |
 | 15 | **ip_connection** | IP-Connection | 1 | A network connection that originates from a source and is addressed to a destination. Source and destination addresses may be either IPv4 or IPv6; both should be the same version |
 | 13 | **mac_addr** | MAC-Addr | 1 | A Media Access Control (MAC) address - EUI-48 or EUI-64 |
 | 17 | **process** | Process | 1 | Common properties of an instance of a computer program as executed on an operating system. |
-| 25 | **properties** | Properties | 1 | Data attribute associated with an actuator |
+| 25 | **properties** | Properties | 1 | Data attribute associated with an Actuator |
 | 19 | **uri** | URI | 1 | A uniform resource identifier(URI). |
 | 1000 | **extension** | PE-Target | 1 | Targets defined in a Private Enterprise extension profile. |
 | 1001 | **extension_unr** | Unr-Target | 1 | Targets defined in an Unregistered extension profile |
 | 1024 | **slpf** | slpf:Target | 1 | **Example Target Extension**: Targets defined in the Stateless Packet Filter profile |
 
-The following targets are under consideration for use in future versions of the Language Specification. Implementers may use these targets with the understanding that they may not be in future versions of the language.
+The following Targets are under consideration for use in future versions of the Language Specification. Implementers may use these Targets with the understanding that they may not be in future versions of the language.
 
 * directory
 * disk
@@ -522,7 +522,7 @@ The following targets are under consideration for use in future versions of the 
 
 **Usage Requirements:**
 
-* The TARGET field in an OpenC2 Command MUST contain exactly one type of target (e.g. ip_addr).
+* The TARGET field in a Command MUST contain exactly one type of Target (e.g. ip_addr).
 
 #### 3.3.1.3 Actuator
 **_Type: Actuator (Choice)_**
@@ -537,16 +537,16 @@ The following targets are under consideration for use in future versions of the 
 
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| 1 | **start_time** | Date-Time | 0..1 | The specific date/time to initiate the action  |
-| 2 | **stop_time** | Date-Time | 0..1 | The specific date/time to terminate the action |
-| 3 | **duration** | Duration | 0..1 | The length of time for an action to be in effect |
-| 4 | **response_requested** | Response-Type | 0..1 | The type of response required for the action: `none`, `ack`, `status`, `complete`. |
+| 1 | **start_time** | Date-Time | 0..1 | The specific date/time to initiate the Action  |
+| 2 | **stop_time** | Date-Time | 0..1 | The specific date/time to terminate the Action |
+| 3 | **duration** | Duration | 0..1 | The length of time for an Action to be in effect |
+| 4 | **response_requested** | Response-Type | 0..1 | The type of Response required for the Action: `none`, `ack`, `status`, `complete`. |
 | 1000 | **extension** | PE-Args | 0..1 | Command arguments defined in a Private Enterprise extension profile |
 | 1001 | **extension_unr** | Unr-Args | 0..1 | Command arguments defined in an Unregistered extension profile |
 
 **Usage Requirements:**
 
-* When response_requested is not explicitly contained in an OpenC2 Command, a Consumer MUST respond in the same manner as {"response_requested": "complete"}.
+* When response_requested is not explicitly contained in a Command, a Consumer MUST respond in the same manner as {"response_requested": "complete"}.
 
 ### 3.3.2 OpenC2 Response
 **_Type: OpenC2-Response (Record)_**
@@ -554,14 +554,14 @@ The following targets are under consideration for use in future versions of the 
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | **status** | Status-Code | 1 | An integer status code |
-| 2 | **status_text** | String | 0..1 | A free-form human-readable description of the response status |
+| 2 | **status_text** | String | 0..1 | A free-form human-readable description of the Response status |
 | 3 | **strings** | String | 0..n | Generic set of string values |
 | 4 | **ints** | Integer | 0..n | Generic set of integer values |
 | 5 | **kvps** | KVP | 0..n | Generic set of key:value pairs |
-| 6 | **versions** | Version | 0..n | List of OpenC2 language versions supported by this actuator |
-| 7 | **profiles** | jadn:Uname | 0..n | List of profiles supported by this actuator |
-| 8 | **schema** | jadn:Schema | 0..1 | Syntax of the OpenC2 language elements supported by this actuator |
-| 9 | **pairs** | Action-Targets | 0..n | List of targets applicable to each supported action |
+| 6 | **versions** | Version | 0..n | List of OpenC2 language versions supported by this Actuator |
+| 7 | **profiles** | jadn:Uname | 0..n | List of profiles supported by this Actuator |
+| 8 | **schema** | jadn:Schema | 0..1 | Syntax of the OpenC2 language elements supported by this Actuator |
+| 9 | **pairs** | Action-Targets | 0..n | List of Targets applicable to each supported Action |
 | 10 | **rate_limit** | Number | 0..1 | Maximum number of requests per minute supported by design or policy |
 | 1000 | **extension** | PE-Results | 0..1 | Response data defined in a Private Enterprise extension profile |
 | 1001 | **extension_unr** | Unr-Results | 0..1 | Response data defined in an unregistered extension profile |
@@ -586,19 +586,19 @@ Usage Requirements:
 
 | ID | Description |
 | :--- | :--- |
-| 102 | **Processing** - an interim response used to inform the producer that the consumer has accepted the request but has not yet completed it. |
+| 102 | **Processing** - an interim Response used to inform the Producer that the Consumer has accepted the request but has not yet completed it. |
 | 200 | **OK** - the request has succeeded. |
 | 301 | **Moved Permanently** - the target resource has been assigned a new permanent URI. |
-| 400 | **Bad Request** - the consumer cannot process the request due to something that is perceived to be a producer error (e.g., malformed request syntax). |
+| 400 | **Bad Request** - the Consumer cannot process the request due to something that is perceived to be a Producer error (e.g., malformed request syntax). |
 | 401 | **Unauthorized** - the request lacks valid authentication credentials for the target resource or authorization has been refused for the submitted credentials. |
-| 403 | **Forbidden** - the consumer understood the request but refuses to authorize it. |
-| 404 | **Not Found** - the consumer has not found anything matching the request. |
-| 500 | **Internal Error** - the consumer encountered an unexpected condition that prevented it from fulfilling the request. |
-| 501 | **Not Implemented** - the consumer does not support the functionality required to fulfill the request. |
-| 503 | **Service Unavailable** - the consumer is currently unable to handle the request due to a temporary overloading or maintenance of the consumer. |
+| 403 | **Forbidden** - the Consumer understood the request but refuses to authorize it. |
+| 404 | **Not Found** - the Consumer has not found anything matching the request. |
+| 500 | **Internal Error** - the Consumer encountered an unexpected condition that prevented it from fulfilling the request. |
+| 501 | **Not Implemented** - the Consumer does not support the functionality required to fulfill the request. |
+| 503 | **Service Unavailable** - the Consumer is currently unable to handle the request due to a temporary overloading or maintenance of the Consumer. |
 
 ### 3.3.3 Imported Data
-In addition to the targets, actuators, arguments, and other language elements defined in this specification, OpenC2 messages may contain data objects imported from other specifications and/or custom data objects defined by the implementers.  The details are specified in a data profile which contains:
+In addition to the Targets, Actuators, arguments, and other language elements defined in this specification, OpenC2 messages may contain data objects imported from other specifications and/or custom data objects defined by the implementers.  The details are specified in a data profile which contains:
 
 1. a prefix indicating the origin of the imported data object is outside OpenC2:
     * `x_` (profile)
@@ -632,7 +632,7 @@ An element using an imported object identifies it using the nsid:
 }
 ```
 
-A data profile can define its own schema for imported objects, or it can reference content as defined in the specification being imported.  Defining an abstract syntax allows imported objects to be represented in the same format as the containing object.  Referencing content directly from an imported specification results in it being treated as an opaque blob if the imported and containing formats are not the same (e.g., an XML or TLV object imported into a JSON OpenC2 command, or a STIX JSON object imported into a CBOR OpenC2 command).
+A data profile can define its own schema for imported objects, or it can reference content as defined in the specification being imported.  Defining an abstract syntax allows imported objects to be represented in the same format as the containing object.  Referencing content directly from an imported specification results in it being treated as an opaque blob if the imported and containing formats are not the same (e.g., an XML or TLV object imported into a JSON Command, or a STIX JSON object imported into a CBOR Command).
 
 The OpenC2 Language MAY be extended using imported data objects for TARGET, TARGET_SPECIFIER, ACTUATOR, ACTUATOR_SPECIFIER, ARGUMENTS, and RESULTS. The list of ACTIONS in Section 3.2.1.2 SHALL NOT be extended.
 
@@ -644,11 +644,11 @@ Organizations may extend the functionality of OpenC2 by defining organization-sp
     * See [RFC5612]
       * iana&iana.org
 
-OpenC2 contains four predefined extension points to support registered private enterprise profiles: PE-Target, PE-Specifiers, PE-Args, and PE-Results.  An organization can develop a profile that defines custom types, create an entry for their organization's namespace under each extension point used in the profile, and then use their custom types within OpenC2 commands and responses.
+OpenC2 contains four predefined extension points to support registered private enterprise profiles: PE-Target, PE-Specifiers, PE-Args, and PE-Results.  An organization can develop a profile that defines custom types, create an entry for their organization's namespace under each extension point used in the profile, and then use their custom types within Commands and Responses.
 
 By convention ID values of 1000 and above within OpenC2-defined data types are namespace identifiers, although there is no restriction against assigning non-namespaced IDs in that range.
 
-This is an example target from a registered profile containing a "lens" extension defined by the organization with IANA Private Enterprise Number 32473. This hypothetical target might be used with the "set" action to support an IoT camera pan-tilt-zoom use case. This example is for illustrative purposes only and MUST NOT use this in actual implementations. 
+This is an example Target from a registered profile containing a "lens" extension defined by the organization with IANA Private Enterprise Number 32473. This hypothetical Target might be used with the "set" Action to support an IoT camera pan-tilt-zoom use case. This example is for illustrative purposes only and MUST NOT use this in actual implementations. 
 
 ```
 {
@@ -662,7 +662,7 @@ This is an example target from a registered profile containing a "lens" extensio
 }
 ```
 
-This is an example of the same target from a profile defined by an organization that has not registered a Private Enterprise Number with IANA.  This example is for illustrative purposes only and MUST NOT use this in actual implementations.
+This is an example of the same Target from a profile defined by an organization that has not registered a Private Enterprise Number with IANA.  This example is for illustrative purposes only and MUST NOT use this in actual implementations.
 
 ```
 {
@@ -681,7 +681,7 @@ Using DNS names provides collision resistance for names used in x- namespaces, b
 OpenC2 implementations MAY support registered and unregistered extension profiles regardless of whether those profiles are listed by OASIS.  Implementations MUST NOT use the "Example" registered extension entries shown below, and MAY use one or more actual registered extensions by replacing the example entries.
 
 #### 3.3.4.1 Private Enterprise Target
-Because target is a required element, implementations receiving an OpenC2 Command with an unsupported target type MUST reject the command as invalid.
+Because Target is a required element, implementations receiving a Command with an unsupported Target type MUST reject the Command as invalid.
 
 **_Type: PE-Target (Choice.ID)_**
 
@@ -690,7 +690,7 @@ Because target is a required element, implementations receiving an OpenC2 Comman
 | 32473 | 32473:Target | 1 | "Example": Targets defined in the Example Inc. extension profile |
 
 #### 3.3.4.2 Private Enterprise Specifiers
-The behavior of an implementation receiving an OpenC2 Command with an unsupported actuator type is undefined.  It MAY ignore the actuator field or MAY reject the command as invalid.
+The behavior of an implementation receiving a Command with an unsupported Actuator type is undefined.  It MAY ignore the Actuator field or MAY reject the Command as invalid.
 
 **_Type: PE-Specifiers (Choice.ID)_**
 
@@ -699,7 +699,7 @@ The behavior of an implementation receiving an OpenC2 Command with an unsupporte
 | 32473 | 32473:Specifiers | 1 | "Example": Actuator Specifiers defined in the Example Inc. extension profile |
 
 #### 3.3.4.3 Private Enterprise Command Arguments
-The behavior of an implementation receiving an OpenC2 Command with an unsupported arg type is undefined.  It MAY ignore the unrecognized arg or MAY reject the command as invalid.
+The behavior of an implementation receiving a Command with an unsupported arg type is undefined.  It MAY ignore the unrecognized arg or MAY reject the Command as invalid.
 
 **_Type: PE-Args (Map.ID)_**
 
@@ -708,7 +708,7 @@ The behavior of an implementation receiving an OpenC2 Command with an unsupporte
 | 32473 | 32473:Args | 1 | "Example": Command Arguments defined in the Example Inc. extension profile |
 
 #### 3.3.4.4 Private Enterprise Results
-The behavior of an implementation receiving an OpenC2 Response with an unsupported results type is undefined.  An unrecognized response has no effect on the OpenC2 protocol but implementations SHOULD log it as an error.
+The behavior of an implementation receiving a Response with an unsupported results type is undefined.  An unrecognized Response has no effect on the OpenC2 protocol but implementations SHOULD log it as an error.
 
 **_Type: PE-Results (Map.ID)_**
 
@@ -749,7 +749,7 @@ The behavior of an implementation receiving an OpenC2 Response with an unsupport
 #### 3.4.1.6 Features
 | Type Name | Base Type | Description |
 | :--- | :--- | :--- |
-| **Features** | ArrayOf(Feature) | An array of zero to ten names used to query an actuator for its supported capabilities. |
+| **Features** | ArrayOf(Feature) | An array of zero to ten names used to query an Actuator for its supported capabilities. |
 
 #### 3.4.1.7 File
 **_Type: File (Map)_**
@@ -800,7 +800,7 @@ The behavior of an implementation receiving an OpenC2 Response with an unsupport
 #### 3.4.1.12 Properties
 | Type Name | Base Type | Description |
 | :--- | :--- | :--- |
-| **Properties** | ArrayOf(String) | A list of names that uniquely identify properties of an actuator. |
+| **Properties** | ArrayOf(String) | A list of names that uniquely identify properties of an Actuator. |
 
 #### 3.4.1.13 URI
 | Type Name | Base Type | Description |
@@ -811,7 +811,7 @@ The behavior of an implementation receiving an OpenC2 Response with an unsupport
 #### 3.4.2.1 Request Identifier
 | Type Name | Base Type | Description |
 | :--- | :--- | :--- |
-| **Request-Id** | Binary | A value of up to 128 bits that uniquely identifies a particular command |
+| **Request-Id** | Binary | A value of up to 128 bits that uniquely identifies a particular Command |
 
 #### 3.4.2.2 Date-Time
 | Type Name | Base Type | Description |
@@ -863,16 +863,16 @@ Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any IA
 | **Port** | Integer | Transport Protocol Port Number, RFC 6335 |
 
 #### 3.4.2.10 Feature
-Specifies the results to be returned from a query features command.
+Specifies the results to be returned from a query features Command.
 
 **_Type: Feature (Enumerated)_**
 
 | ID | Name | Description |
 | :--- | :--- | :--- |
-| 1 | **versions** | List of OpenC2 Language versions supported by this actuator |
-| 2 | **profiles** | List of profiles supported by this actuator |
-| 3 | **schema** | Definition of the command syntax supported by this actuator |
-| 4 | **pairs** | List of supported actions and applicable targets |
+| 1 | **versions** | List of OpenC2 Language versions supported by this Actuator |
+| 2 | **profiles** | List of profiles supported by this Actuator |
+| 3 | **schema** | Definition of the Command syntax supported by this Actuator |
+| 4 | **pairs** | List of supported Actions and applicable Targets |
 | 5 | **rate_limit** | Maximum number of requests per minute supported by design or policy |
 
 #### 3.4.2.11 Response-Type
@@ -881,9 +881,9 @@ Specifies the results to be returned from a query features command.
 | ID | Name | Description |
 | :--- | :--- | :--- |
 | 0 | **none** | No response |
-| 1 | **ack** | Respond when command received |
-| 2 | **status** | Respond with progress toward command completion |
-| 3 | **complete** | Respond when all aspects of command completed |
+| 1 | **ack** | Respond when Command received |
+| 2 | **status** | Respond with progress toward Command completion |
+| 3 | **complete** | Respond when all aspects of Command completed |
 
 #### 3.4.2.12 Version
 | Type Name | Base Type | Description |
@@ -903,8 +903,8 @@ Specifies the results to be returned from a query features command.
 
 | ID | Type | # | Description |
 | :--- | :--- | :--- | :--- |
-| 1 | Action | 1 | An action supported by this actuator. |
-| 2 | Target.* | 1..n | List of targets applicable to this action.  The targets are enumerated values derived from the set of Target types. |
+| 1 | Action | 1 | An Action supported by this Actuator. |
+| 2 | Target.* | 1..n | List of Targets applicable to this Action.  The Targets are enumerated values derived from the set of Target types. |
 
 ### 3.4.3 Schema Syntax
 **3.4.3.1 Schema**
@@ -1036,42 +1036,42 @@ Field definition for compound types Array, Choice, Map, Record
 -------
 
 # 4 Mandatory Commands/Responses 
-An OpenC2 command consists of an ACTION/TARGET pair and associated SPECIFIERS and ARGUMENTs.  This section enumerates the allowed commands, identify which are required or optional to implement, and present the associated responses.  
+A Command consists of an ACTION/TARGET pair and associated SPECIFIERS and ARGUMENTs.  This section enumerates the allowed Commands, identify which are required or optional to implement, and present the associated Responses.
 
-An OpenC2 Consumer MUST process an OpenC2 Command where "query" is specified for the ACTION and "features" is specified for the TARGET, hereafter, referred to as a 'query features' command".
+A Consumer MUST process a Command where "query" is specified for the ACTION and "features" is specified for the TARGET, hereafter, referred to as a 'query features' Command".
 
-Upon processing a 'query features'  command, an OpenC2 Consumer MUST issue an OpenC2 Response to the OpenC2 Producer that issued the OpenC2 Command.
+Upon processing a 'query features' Command, an Consumer MUST issue a Response to the Producer that issued the Command.
 
 -------
 
 # 5 Conformance
-## 5.1 OpenC2 Message Content
-A conformant OpenC2 Command 
+## 5.1 Message Content
+A conformant Command 
 
 1. MUST be structured in accordance with Section 3.4.1, and 
 2. MUST include exactly one ACTION specified in Section 3.4.1.1.
 
-A conformant OpenC2 Response
+A conformant Response
 
 1. MUST be structured in accordance with Section 3.4.2, and 
 2. MUST include exactly one STATUS specified in Section 3.4.2.1.
 
-## 5.2 OpenC2 Producer
-A conformant OpenC2 Producer 
+## 5.2 Producer
+A conformant Producer 
 
-1. MUST issue OpenC2 Commands and process OpenC2 Responses specified in Section 4
-2. MUST implement JSON serialization of generated OpenC2 Commands in accordance with RFC 7493
+1. MUST issue Commands and process Responses specified in Section 4
+2. MUST implement JSON serialization of generated Commands in accordance with RFC 7493
 
-## 5.3 OpenC2 Consumer
-A conformant OpenC2 Consumer 
+## 5.3 Consumer
+A conformant Consumer 
 
-1. MUST process OpenC2 Commands and issue OpenC2 Responses specified in Section 4
-2. MUST implement JSON serialization of generated OpenC2 Responses in accordance with RFC 7493
+1. MUST process Commands and issue Responses specified in Section 4
+2. MUST implement JSON serialization of generated Responses in accordance with RFC 7493
 
 -------
 
 # Annex A. Schemas
-This annex defines the information model used by conforming OpenC2 implementations in JSON Abstract Data Notation (JADN) format.  JADN is a structured textual representation of the tables shown in Section 3.  Schema files referenced by the URLs include descriptive text shown in the tables.  Descriptions are omitted from the figures in this section in order to: 1) illustrate that descriptive text is not part of the language syntax, 2) show what an actuator would return in response to a schema query, and 3) improve readability of the figures. 
+This annex defines the information model used by conforming OpenC2 implementations in JSON Abstract Data Notation (JADN) format.  JADN is a structured textual representation of the tables shown in Section 3.  Schema files referenced by the URLs include descriptive text shown in the tables.  Descriptions are omitted from the figures in this section in order to: 1) illustrate that descriptive text is not part of the language syntax, 2) show what an Actuator would return in response to a schema query, and 3) improve readability of the figures. 
 
 ## A.1 OpenC2 Language Syntax
 **Schema File:**
@@ -1086,7 +1086,7 @@ The normative schema file (oc2ls.json) and formatted version (oc2ls.pdf) may be 
   "module": "oasis-open.org/openc2/v1.0/openc2-lang",
   "patch": "wd09",
   "title": "OpenC2 Language Objects",
-  "description": "Datatypes that define the content of OpenC2 commands and responses.",
+  "description": "Datatypes that define the content of Commands and Responses.",
   "imports": [
    ["slpf", "oasis-open.org/openc2/v1.0/ap-slpf"],
    ["jadn", "oasis-open.org/openc2/v1.0/jadn"]
@@ -1386,9 +1386,9 @@ The normative schema file (jadn.json) and formatted version (jadn.pdf) may be fo
 
 # Annex B. Examples
 ## B.1 Example 1
-This example shows the elements of an OpenC2 Message containing an OpenC2 Command. The content of the message is the de-serialized command structure in whatever format is used by the implementation, independent of the transfer protocol and serialization format used to transport the message.
+This example shows the elements of an OpenC2 Message containing a Command. The content of the message is the de-serialized Command structure in whatever format is used by the implementation, independent of the transfer protocol and serialization format used to transport the message.
 
-The request_id in this example is a 64 bit binary value which can be displayed in many ways, including hex:` 'd937 fca9 2b64 4e71'`,  base64url: `'2Tf8qStkTnE'`, and Python byte string - ASCII characters with hex escapes (\xNN) for non-ASCII bytes: `b'\xd97\xfc\xa9+dNq'`.  If OpenC2 producers generate numeric or alphanumeric request_ids, they are still binary values and are limited to 128 bits, e.g.,: hex: '6670 2d31 3932 352d 3337 3632 3864 3663', base64url: 'ZnAtMTkyNS0zNzYyOGQ2Yw', byte string: b'fp-1925-37628d6c'.
+The request_id in this example is a 64 bit binary value which can be displayed in many ways, including hex:` 'd937 fca9 2b64 4e71'`,  base64url: `'2Tf8qStkTnE'`, and Python byte string - ASCII characters with hex escapes (\xNN) for non-ASCII bytes: `b'\xd97\xfc\xa9+dNq'`.  If Producers generate numeric or alphanumeric request_ids, they are still binary values and are limited to 128 bits, e.g.,: hex: '6670 2d31 3932 352d 3337 3632 3864 3663', base64url: 'ZnAtMTkyNS0zNzYyOGQ2Yw', byte string: b'fp-1925-37628d6c'.
 
 The created element is a Date-Time value of milliseconds since the epoch.  The example `1539355895215` may be displayed as` '12 October 2018 14:51:35 UTC'`.
 
@@ -1405,9 +1405,9 @@ created: 1539355895215
 content: {'action': 'query', 'target': {'features': ['versions', 'profiles']}}
 
 ### B.1.2 Response Message
-The response message contains a status code, a content-type that is normally the same as the request content type, a msg_type of `'response'`, and the response content.  The request_id from the command message, if present, is returned unchanged in the response message.  The "to" element of the response normally echoes the "from" element of the command message, but the "from" element of the response is the actuator's identifier regardless of whether the command was sent to an individual actuator or a group.  The "created" element, if present, contains the creation time of the response.
+The Response message contains a status code, a content-type that is normally the same as the request content type, a msg_type of `'response'`, and the Response content.  The request_id from the Command message, if present, is returned unchanged in the Response message.  The "to" element of the Response normally echoes the "from" element of the Command message, but the "from" element of the Response is the Actuator's identifier regardless of whether the Command was sent to an individual Actuator or a group.  The "created" element, if present, contains the creation time of the Response.
 
-A responder could potentially return non-openc2 content, such as a PDF report or an HTML document, in response to an openc2 command.  No actuator profiles currently define response content types other than openc2.
+A responder could potentially return non-openc2 content, such as a PDF report or an HTML document, in response to a Command.  No Actuator profiles currently define response content types other than openc2.
 
 status: 200
 content-type: 'application/openc2'
@@ -1470,7 +1470,7 @@ This example is for a transport where the header information is outside the JSON
 
 **Command:**
 
-This command queries the actuator for the syntax of its supported commands.
+This Command queries the Actuator for the syntax of its supported Commands.
 
 ```
 {
@@ -1483,9 +1483,9 @@ This command queries the actuator for the syntax of its supported commands.
 
 **Response:**
 
-This example illustrates how actuator developers tailor the OpenC2 schema to communicate the capabilities of their products to producers.  This example actuator supports the mandatory requirements of the language specification plus a random subset of optional language elements (cancel, create, and delete actions, and the command, ip_addr, and properties targets).  The example actuator supports a subset of the core OpenC2 language but no profile-defined targets, actuator specifiers, command arguments, or responses.
+This example illustrates how Actuator developers tailor the OpenC2 schema to communicate the capabilities of their products to Producers.  This example Actuator supports the mandatory requirements of the language specification plus a random subset of optional language elements (cancel, create, and delete Actions, and the Command, ip_addr, and properties Targets).  The example Actuator supports a subset of the core OpenC2 language but no profile-defined Targets, Actuator specifiers, Command arguments, or Responses.
 
-The example do-nothing actuator appears to support create and delete  ip_addr commands, but without a profile there is no definition of what the actuator would do to "create" an IP address.  The schema is used by producers to determine what commands are syntactically valid for an actuator, but it does not assign meaning to those commands.
+The example do-nothing Actuator appears to support create and delete  ip_addr commands, but without a profile there is no definition of what the Actuator would do to "create" an IP address.  The schema is used by Producers to determine what Commands are syntactically valid for an Actuator, but it does not assign meaning to those Commands.
 
 ```
 {
@@ -1650,7 +1650,7 @@ The example do-nothing actuator appears to support create and delete  ip_addr co
 | :--- | :--- | :--- | :--- |
 | v1.0-wd01 | 10/31/2017 | Romano, Sparrell | Initial working draft |
 | v1.0-csd01 | 11/14/2017 | Romano, Sparrell | approved wd01 |
-| v1.0-wd02 | 01/12/2018 | Romano, Sparrell | csd01 ballot comments<br>targets |
+| v1.0-wd02 | 01/12/2018 | Romano, Sparrell | csd01 ballot comments<br>Targets |
 | v1.0-wd03 | 01/31/2018 | Romano, Sparrell | wd02 review comments |
 | v1.0-csd02 | 02/14/2018 | Romano, Sparrell | approved wd03 |
 | v1.0-wd04 | 03/02/2018 | Romano, Sparrell | Property tables<br>threads (cmd/resp) from use cases<br>previous comments |
@@ -1658,7 +1658,7 @@ The example do-nothing actuator appears to support create and delete  ip_addr co
 | v1.0-csd03 | 04/03/2018 | Romano, Sparrell | approved wd05 |
 | v1.0-wd06 | 05/15/2018 | Romano, Sparrell | Finalizing message structure<br>message=header+body<br>Review comments<br>Using word ‘arguments’ instead of ‘options’ |
 | v1.0-csd04 | 5/31/2018 | Romano, Sparrell | approved wd06 |
-| v1.0-wd07 | 7/11/2018 | Romano, Sparrell | Continued refinement of details<br>Review comments<br>Moved some actions and targets to reserved lists |
+| v1.0-wd07 | 7/11/2018 | Romano, Sparrell | Continued refinement of details<br>Review comments<br>Moved some Actions and Targets to reserved lists |
 | v1.0-wd08 | 10/05/2018 | Romano, Sparrell | Continued refinement of details<br>Review comments |
 | v1.0-wd09 | 10/17/2018 | Romano, Sparrell | Additional review comments to create wd09 for CSD approval and release for public review. |
 


### PR DESCRIPTION
This addresses a more general issue related to Issue #214 about using consistent terminology. When used as defined in Section 1.5, the terms Action, Actuator, Command, Consumer, Producer, Response, and Target are all formatted with an initial capital letter.

We may want to extend this to other terms like Argument and Profile.