### PR TITLE
add "description" as cmd arg

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1245,8 +1245,10 @@ The OpenC2 Namespace Registry is the most current list of active and proposed Ac
 |----|------------------------|---------------|------|-------------------------------------------------------------------------------------|
 | 1  | **start_time**         | Date-Time     | 0..1 | The specific date/time to initiate the Command                                      |
 | 2  | **stop_time**          | Date-Time     | 0..1 | The specific date/time to terminate the Command                                     |
-| 3  | **duration**           | Duration      | 0..1 | The length of time for a Command to be in effect                                   |
+| 3  | **duration**           | Duration      | 0..1 | The length of time for a Command to be in effect                                    |
 | 4  | **response_requested** | Response-Type | 0..1 | The type of Response required for the Command: `none`, `ack`, `status`, `complete`. |
+| 5  | **description**        | String        | 0..1 | A human-readable note to annotate or provide information regarding the action.      |
+
 
 **Usage Requirements:**
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1247,7 +1247,7 @@ The OpenC2 Namespace Registry is the most current list of active and proposed Ac
 | 2  | **stop_time**          | Date-Time     | 0..1 | The specific date/time to terminate the Command                                     |
 | 3  | **duration**           | Duration      | 0..1 | The length of time for a Command to be in effect                                    |
 | 4  | **response_requested** | Response-Type | 0..1 | The type of Response required for the Command: `none`, `ack`, `status`, `complete`. |
-| 5  | **description**        | String        | 0..1 | A human-readable note to annotate or provide information regarding the action.      |
+| 5  | **comment**            | String        | 0..1 | A human-readable note to annotate or provide information regarding the action.      |
 
 
 **Usage Requirements:**


### PR DESCRIPTION
This PR responds to LS issue #369 and adds the `description` argument proposed in the PF AP ([Section 2.1.3.2](https://github.com/oasis-tcs/openc2-ap-pf/blob/working/oc2pf.md#2132-command-arguments-unique-to-pf)) to the LS instead. 

If this PR is approved, Section 2.1.3.2 of the PF AP should be edited to remove this as an AP-unique argument.