### PR TITLE
address RR=None plus Consumer error (issues #386, 387)

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1272,22 +1272,28 @@ The OpenC2 Namespace Registry is the most current list of active and proposed Ac
 
 -   `response_requested`:
 
-    -   If `response_requested` is specified as `none` then the Consumer SHOULD
-        NOT send a Response.
+    -   If `response_requested` is specified as `none` and the
+        Consumer successfully executes the Command then the
+        Consumer SHOULD NOT send a Response.
 
-        -   If `response_requested` is specified as `ack` then the Consumer
+    -   If `response_requested` is specified as `none` and the
+        Consumer encounters an error then the Consumer SHOULD
+        send a Response with a `status` consistent with the error
+        detected.
+
+    -   If `response_requested` is specified as `ack` then the Consumer
             SHOULD send a Response acknowledging receipt of the Command:
             `{"status": 102}`.
 
-        -   If `response_requested` is specified as `status` then the Consumer
+    -   If `response_requested` is specified as `status` then the Consumer
             SHOULD send a Response containing the current status of Command
             execution.
 
-        -   If `response_requested` is specified as `complete` then the Consumer
+    -   If `response_requested` is specified as `complete` then the Consumer
             SHOULD send a Response containing the status or results upon
             completion of Command execution.
 
-        -   If `response_requested` is not explicitly specified then the
+    -   If `response_requested` is not explicitly specified then the
             Consumer SHOULD respond as if `complete` was specified.
 
 ### 3.3.2 OpenC2 Response
@@ -2528,6 +2534,7 @@ the "Target" data type.
 | Revision   | Date       | Editor           | Changes Made                                                                                              |
 |------------|------------|------------------|-----------------------------------------------------------------------------------------------------------|
 | v1.1-wd01  | 10/31/2017 | Sparrell, Considine | Initial working draft                                                                                     |
+| issue 386, 387 | 08/xx/2022 | Lemire | Adjust `response_requested` handling (3.3.1.4) to consider Consumer error situations | 
 
 # Appendix F. Acknowledgments
 


### PR DESCRIPTION
This PR addresses issues #386 and #387, per discussion at the 8/10/2022 working meeting. 

 - adjust `response_requested` usage requirements in 3.3.1.4 to account for Consumer error situations
 - add tracking of this change to Revision History table (Appendix E)

EDIT: I believe this is a non-breaking change