### PR TITLE
clarify Version string format (issue #388)

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1743,9 +1743,15 @@ Identifies the type of Message.
 
 #### 3.4.2.17 Version
 
+Used to report the version(s) of OpenC2 supported by Consumers.
+
 | Type Name   | Type Definition | Description                |
 |-------------|-----------------|----------------------------|
-| **Version** | String          | Major.Minor version number |
+| **Version** | String          | OpenC2 version in "Major.Minor" format |
+
+**Usage Requirement:**
+
+-   A Version string MUST contain the major and minor version numbers, represented as integers seperated by a period (e.g., "1.1").
 
 # 4 Mandatory Commands/Responses
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1751,7 +1751,9 @@ Used to report the version(s) of OpenC2 supported by Consumers.
 
 **Usage Requirement:**
 
--   A Version string MUST contain the major and minor version numbers, represented as integers seperated by a period (e.g., "1.1").
+-   A Version string MUST contain the major and minor version
+    numbers, represented as integers seperated by a period (e.g.,
+    "1.1").
 
 # 4 Mandatory Commands/Responses
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2536,6 +2536,7 @@ the "Target" data type.
 | Revision   | Date       | Editor           | Changes Made                                                                                              |
 |------------|------------|------------------|-----------------------------------------------------------------------------------------------------------|
 | v1.1-wd01  | 10/31/2017 | Sparrell, Considine | Initial working draft                                                                                     |
+| issue 388, item 4 | 08/xx/2022 | Lemire | Add usage requirement for `Version` format in 3.4.2.17   |
 
 # Appendix F. Acknowledgments
 


### PR DESCRIPTION
This PR responds to item 4 in issue #388, regarding the `Version` data type. Per discussion at the 8/10/2022 working meeting, since this type is only used to report openC2 versions, its format can be limited for that purpose.

Also adds a change tracking entry in Revision History table.

EDIT: I believe this is a non-breaking change