### PR TITLE
Document Use Of External registries

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2130,6 +2130,11 @@ https://standards.ieee.org/content/dam/ieee-standards/standards/web/documents/tu
 "IEEE Registration Authority: Assignments", IEEE, August 2022,
 https://regauth.standards.ieee.org/standards-ra-web/pub/view.html#registries
 
+###### [IANA_Protocols]
+
+"Internet Assigned Numbers Authority Protocol Numbers", IANA,
+August 2022, https://www.iana.org/assignments/protocol-numbers
+
 
 ## A.2 Informative References
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -826,7 +826,9 @@ specify value constraints for which an authoritative definition exists.
 
 **Usage Requirements:**
 
--   Properties identified as conforming to `eui` should be interpreted according to the values documented in the [[IEEE Registration Authority registry]](#ieee_ra).
+-   Properties identified as conforming to `eui` should be
+    interpreted according to the values documented in the [[IEEE
+    Registration Authority registry]](#ieee_ra).
 
 ### 3.1.3 Multiplicity
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1689,11 +1689,11 @@ Specifies the results to be returned from a query features Command.
 
 #### 3.4.2.10 L4 Protocol
 
-Value of the protocol (IPv4) or next header (IPv6) field in an IP
-packet. Recognized values for these fields are registered with
-IANA, according to the process defined in [[RFC5237]](#rfc5237).
-The table below identifies a non-exhaustive set of commonly used
-values.
+Value of the IPv4 `"protocol"` or IPv6 `"next header"` field in
+an IP packet. Recognized values for these fields are registered
+with IANA, according to the process defined in
+[[RFC5237]](#rfc5237). The table below identifies a
+non-exhaustive set of commonly used values.
 
 **Type: L4-Protocol (Enumerated)**
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1696,6 +1696,7 @@ values.
 | 1   | **icmp** | Internet Control Message Protocol - [[RFC0792]](#rfc0792)    |
 | 6   | **tcp**  | Transmission Control Protocol - [[RFC9293]](#rfc9293)        |
 | 17  | **udp**  | User Datagram Protocol - [[RFC0768]](#rfc0768)               |
+| 28  | **ipv6_icmp**  | ICMP for IPv6 - [[RFC8200]](#rfc8200)                  |
 | 132 | **sctp** | Stream Control Transmission Protocol - [[RFC4960]](#rfc4960) |
 
 **Usage Requirement:**

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2565,6 +2565,7 @@ the "Target" data type.
 | Revision   | Date       | Editor           | Changes Made                                                                                              |
 |------------|------------|------------------|-----------------------------------------------------------------------------------------------------------|
 | v1.1-wd01  | 10/31/2017 | Sparrell, Considine | Initial working draft                                                                                     |
+| issue 388, item 1, 390 | 08/xx/2022 | Lemire | Add guidance in 3.1.2, 3.4.1.1, 3.4.2.10 regarding types that depend on external registries, and add associated references; update RFC reference for TCP |
 
 # Appendix F. Acknowledgments
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1410,7 +1410,7 @@ specified for serializations other than JSON.
 
 | ID | Name          | Type    | \#   | Description                                                                        |
 |----|---------------|---------|------|------------------------------------------------------------------------------------|
-| 1  | **media_type** | String  | 0..1 | Media types description formatted as specified in [RFC6838](#rfc6838)             |
+| 1  | **media_type** | String  | 0..1 | Media type description formatted as specified in [RFC6838](#rfc6838)             |
 | 2  | **payload**   | Payload | 0..1 | Choice of literal content or URL                                                   |
 | 3  | **hashes**    | Hashes  | 0..1 | Hashes of the payload content                                                      |
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2135,6 +2135,11 @@ https://regauth.standards.ieee.org/standards-ra-web/pub/view.html#registries
 "Internet Assigned Numbers Authority Protocol Numbers", IANA,
 August 2022, https://www.iana.org/assignments/protocol-numbers
 
+###### [IANA_Media]
+
+"Internet Assigned Numbers Authority Media Types", IANA,
+August 2022, https://www.iana.org/assignments/media-types
+
 
 ## A.2 Informative References
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1680,8 +1680,11 @@ Specifies the results to be returned from a query features Command.
 
 #### 3.4.2.10 L4 Protocol
 
-Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any
-IANA value, [[RFC5237]](#rfc5237)
+Value of the protocol (IPv4) or next header (IPv6) field in an IP
+packet. Recognized values for these fields are registered with
+IANA, according to the process defined in [[RFC5237]](#rfc5237).
+The table below identifies a non-exhaustive set of commonly used
+values.
 
 **Type: L4-Protocol (Enumerated)**
 
@@ -1691,6 +1694,13 @@ IANA value, [[RFC5237]](#rfc5237)
 | 6   | **tcp**  | Transmission Control Protocol - [[RFC0793]](#rfc0793)        |
 | 17  | **udp**  | User Datagram Protocol - [[RFC0768]](#rfc0768)               |
 | 132 | **sctp** | Stream Control Transmission Protocol - [[RFC4960]](#rfc4960) |
+
+**Usage Requirement:**
+
+-   The IPv4 Protocol field and IPv6 Next Header field are 8-bit
+    values, therefore L4-Protocol is an enumeration from 0..255.
+-   Values of L4-Protocol should be interpreted as documented in
+    [[IANA_Protocols]](#iana_protocols)
 
 #### 3.4.2.11 Message-Type
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2129,6 +2129,12 @@ Rundgren, A., Jordan, B., and S. Erdtman, "JSON Canonicalization Scheme (JCS)",
 RFC 8785, DOI 10.17487/RFC8785, June 2020,
 <https://www.rfc-editor.org/info/rfc8785>.
 
+###### [RFC9293]
+
+Eddy, W., "Transmission Control Protocol (TCP)", RFC 9293, DOI:
+10.17487/RFC9293, August 2022,
+<https://www.rfc-editor.org/info/rfc8785>.
+
 ###### [EUI]
 
 "IEEE Registration Authority Guidelines for use of EUI, OUI, and CID", IEEE,

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1425,7 +1425,7 @@ specified for serializations other than JSON.
 -   An "Artifact" Target MUST contain at least one property.
 -   `media_type` "Artifact" property values should be intepreted
     according to the values documented  in the [IANA Media Types
-    registry](#iana_media)
+    registry](#iana_media).
 
 #### 3.4.1.2 Device
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1704,7 +1704,7 @@ values.
 -   The IPv4 Protocol field and IPv6 Next Header field are 8-bit
     values, therefore L4-Protocol is an enumeration from 0..255.
 -   Values of L4-Protocol should be interpreted as documented in
-    [[IANA_Protocols]](#iana_protocols)
+    [[IANA_Protocols]](#iana_protocols).
 
 #### 3.4.2.11 Message-Type
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2125,6 +2125,12 @@ RFC 8785, DOI 10.17487/RFC8785, June 2020,
 August 2017,
 https://standards.ieee.org/content/dam/ieee-standards/standards/web/documents/tutorials/eui.pdf
 
+###### [IEEE_RA]
+
+"IEEE Registration Authority: Assignments", IEEE, August 2022,
+https://regauth.standards.ieee.org/standards-ra-web/pub/view.html#registries
+
+
 ## A.2 Informative References
 
 ###### [RFC3552]

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1977,11 +1977,6 @@ Postel, J., "Internet Protocol", STD 5, RFC 791, DOI 10.17487/RFC0791, September
 Postel, J., "Internet Control Message Protocol", STD 5, RFC 792, DOI
 10.17487/RFC0792, September 1981, <https://www.rfc-editor.org/info/rfc792>.
 
-###### [RFC0793]
-
-Postel, J., "Transmission Control Protocol", STD 7, RFC 793, DOI
-10.17487/RFC0793, September 1981, <https://www.rfc-editor.org/info/rfc793>.
-
 ###### [RFC1034]
 
 Mockapetris, P., "Domain names - concepts and facilities", STD 13, RFC 1034, DOI

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -824,6 +824,10 @@ specify value constraints for which an authoritative definition exists.
 | **iri**          | String          | Value must be an Internationalized Resource Identifier (IRI) as defined in [[RFC3987]](#rfc3987) |
 | **uri**          | String          | Value must be a Uniform Resource Identifier (URI) as defined in [[RFC3986]](#rfc3986)            |
 
+**Usage Requirements:**
+
+-   Properties identified as conforming to `eui` should be interpreted according to the values documented in the [[IEEE Registration Authority registry]](#ieee_ra).
+
 ### 3.1.3 Multiplicity
 
 Property tables for types based on Array, Choice, Map and Record include a
@@ -1410,7 +1414,7 @@ specified for serializations other than JSON.
 
 | ID | Name          | Type    | \#   | Description                                                                        |
 |----|---------------|---------|------|------------------------------------------------------------------------------------|
-| 1  | **media_type** | String  | 0..1 | Media type description formatted as specified in [RFC6838](#rfc6838)             |
+| 1  | **media_type** | String  | 0..1 | Media type description formatted as specified in [[RFC6838]](#rfc6838)             |
 | 2  | **payload**   | Payload | 0..1 | Choice of literal content or URL                                                   |
 | 3  | **hashes**    | Hashes  | 0..1 | Hashes of the payload content                                                      |
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1691,7 +1691,7 @@ values.
 | ID  | Name     | Description                                                  |
 |-----|----------|--------------------------------------------------------------|
 | 1   | **icmp** | Internet Control Message Protocol - [[RFC0792]](#rfc0792)    |
-| 6   | **tcp**  | Transmission Control Protocol - [[RFC0793]](#rfc0793)        |
+| 6   | **tcp**  | Transmission Control Protocol - [[RFC9293]](#rfc9293)        |
 | 17  | **udp**  | User Datagram Protocol - [[RFC0768]](#rfc0768)               |
 | 132 | **sctp** | Stream Control Transmission Protocol - [[RFC4960]](#rfc4960) |
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1410,13 +1410,16 @@ specified for serializations other than JSON.
 
 | ID | Name          | Type    | \#   | Description                                                                        |
 |----|---------------|---------|------|------------------------------------------------------------------------------------|
-| 1  | **mime_type** | String  | 0..1 | Permitted values specified in the IANA Media Types registry, [[RFC6838]](#rfc6838) |
+| 1  | **media_type** | String  | 0..1 | Media types description formatted as specified in [RFC6838](#rfc6838)             |
 | 2  | **payload**   | Payload | 0..1 | Choice of literal content or URL                                                   |
 | 3  | **hashes**    | Hashes  | 0..1 | Hashes of the payload content                                                      |
 
 **Usage Requirement:**
 
 -   An "Artifact" Target MUST contain at least one property.
+-   `media_type` "Artifact" property values should be intepreted
+    according to the values documented  in the [IANA Media Types
+    registry](#iana_media)
 
 #### 3.4.1.2 Device
 


### PR DESCRIPTION
This PR addresses issue #390 and item 1 in issue #388:

1. adds references for IANA protocol number and media type registries
2. adds a reference for the IEEE Registration Authority Assignments page
3. updates the TCP reference to the [new RFC 9293](https://www.rfc-editor.org/rfc/rfc9293.html)
4. adds guidance to 3.1.2 interpret EUI types as defined by the IEEE Registration Authority : Assignments registry
5. renames `mime_type` in 3.4.1.1 to `media_type` IAW current IANA terminology, adds clarifying language to interpret values based on the IANA media type registry
6. adds clarifying language to 3.4.2.10, L4-Protocol, to interpret values based on the IANA protocol numbers registry, and adds additional example values
7. adds a change tracking entry to Revision History 

EDIT : The change from `mime_type` to `media_type` makes this a **breaking change**.