### PR TITLE
Create JADN Appendix

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2766,10 +2766,6 @@ using JIDL in the preceding section.
 
 > JADN translation to JSON schema
 
-### D.3.4  Translation to CBOR / CDDL
-
-> JADN translation to CBOR/CDDL
-
 ## D.5 Additional Information
 
 > Reference to OpenC2 JADN schema external artifact

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2231,7 +2231,7 @@ Birkholz, H., Vigano, C. and Bormann, C., "Concise Data Definition Language (CDD
 "What is IACD", __IACD__, Integrated Adaptive Cyber Defense, 3/17/2018, https://www.iacdautomate.org/
 
 ###### [JSON-Schema]
-"JSON Schema, a vocabulary that allows you to annotate and validate JSON documents.", retrieve 9/26/2022, https://json-schema.org/
+"JSON Schema, a vocabulary that allows you to annotate and validate JSON documents.", retrieved 9/26/2022, https://json-schema.org/
 
 ###### [UML]
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2226,6 +2226,9 @@ https://www.rfc-editor.org/info/rfc3552.
 
 "What is IACD", __IACD__, Integrated Adaptive Cyber Defense, 3/17/2018, https://www.iacdautomate.org/
 
+###### [JSON-Schema]
+"JSON Schema, a vocabulary that allows you to annotate and validate JSON documents.", retrieve 9/26/2022, https://json-schema.org/
+
 ###### [UML]
 
 "Unified Modeling Language", Version 2.5.1, December 2017, https://www.omg.org/spec/UML/2.5.1/About-UML/

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2622,7 +2622,7 @@ JADN defines a set of base types that includes five "primitives"
 map, record). JADN type definitions have a fixed structure
 designed to be easily describable, easily processed, stable, and
 extensible. Every definition in a JADN document is described in
-terms of five elements (JADN specifcation section 3.1): 
+terms of five elements (JADN specification section 3.1): 
 
 1) **TypeName:** the name of the type being defined
 2) **BaseType:** the JADN predefined type (Table 3-1) of the type

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2525,7 +2525,7 @@ NrWYJty9TObjiPcu3ZvkE/JCWhD3W1/YPZX6DN5TFZpR2A==
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-# Appendix E. Schema Development With JADN
+# Appendix D. Schema Development With JADN
 
 *The content in this section is non-normative.*
 
@@ -2537,7 +2537,7 @@ otherwise, section references in this appendix are to sections of
 the [JADN](#jadn-v10) specification, rather than this Language
 Specification.
 
-## E.1 JADN Overview
+## D.1 JADN Overview
 
 The abstract of the OASIS Committee Specification for JADN
 describes it as follows:
@@ -2617,7 +2617,7 @@ helpful for visualization of an information model. The JIDL
 format, a simple text structure, is easy to edit, making it a
 good format for the initial creation of a JADN model.
 
-## E.2 Deriving Other Schemas and Serializations
+## D.2 Deriving Other Schemas and Serializations
 
 Once the information model is developed, its use in applications
 requires serialization and deserialization of the information in
@@ -2652,12 +2652,12 @@ serializations (Section 4). Because each serialization represents
 the same information model, translation between serialization
 formats is simplified.
 
-## E.3 JADN Example: OpenC2 Subset
+## D.3 JADN Example: OpenC2 Subset
 
 This section provide a brief example of a JADN information model,
 using data types from OpenC2. 
 
-### E.3.1  Basic and Complex Data Types
+### D.3.1  Basic and Complex Data Types
 
 This example illustrates the use of basic and complex types to
 describe a network connection. A 5-tuple is a common means of
@@ -2730,7 +2730,7 @@ specification). For example, "`ipv4-addr"` is used to force the
 representation of a binary address in "dotted quad"
 representation, per [[RFC 791](#rfc0791)].
 
-### E.3.2  JADN Representation
+### D.3.2  JADN Representation
 
 This section shows the JADN representation of the types defined
 using JIDL in the preceding section.
@@ -2762,15 +2762,15 @@ using JIDL in the preceding section.
 ```
 
 
-### E.3.3  Translation To JSON Schema
+### D.3.3  Translation To JSON Schema
 
 > JADN translation to JSON schema
 
-### E.3.4  Translation to CBOR / CDDL
+### D.3.4  Translation to CBOR / CDDL
 
 > JADN translation to CBOR/CDDL
 
-## E.5 Additional Information
+## D.5 Additional Information
 
 > Reference to OpenC2 JADN schema external artifact
 
@@ -2779,7 +2779,7 @@ using JIDL in the preceding section.
 
 
 
-# Appendix F. Revision History
+# Appendix E. Revision History
 
 *The content in this section is non-normative.*
 
@@ -2797,7 +2797,7 @@ using JIDL in the preceding section.
 | Issue #361 | 9/xx/2022 | Lemire | Add explanatory JADN appendix  |
 
 
-# Appendix G. Acknowledgments
+# Appendix F. Acknowledgments
 
 *The content in this section is non-normative.*
 
@@ -2868,7 +2868,7 @@ specification and are gratefully acknowledged:
 | Sounil     | Yu            | Bank of America                                                      |
 | Vasileios  | Mavroeidis    | University of Oslo                                                   |
 
-# Appendix H. Notices
+# Appendix G. Notices
 
 Copyright © OASIS Open 2021. All Rights Reserved.
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2676,8 +2676,9 @@ data corresponding to the model. Serialization is the process for
 converting application information, regardless of its internal
 representation, into a form that can be transmitted (i.e., into a
 "document"). JADN information models can be translated into a
-number of schemea formats, such as [[JSON schema](#json-schema)] or CDDL, or can be
-used directly as a format-independent schema language.
+number of schemea formats, such as [[JSON schema](#json-schema)]
+or CDDL [[RFC8610](#rfc8610)], or can be used directly as a
+format-independent schema language.
 
 Converting an information model to a data model means applying
 serialization rules for each base type that produce physical data

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2624,6 +2624,22 @@ size and value contstraints, multiplicity constraints) provide
 the means to define a wide variety of information types in a
 representation-independent manner.
 
+The native format of JADN is JSON, but JADN content can be
+represented in others ways that are more useful for
+documentation. The [JADN Specification](#jadn-v10) identifies
+three formats (Section 5):
+
+ - JADN Interface Definition Language (JIDL)
+ - Table Style 
+ - Entity Relationship Diagrams 
+
+Automated tooling makes it straightforward to translate among all
+four of these formats. Table style presentation is often used in
+specifications (e.g., as property tables such as are found in the
+body of this specficiation). Entity relationship diagrams are
+helpful for visualization of an information model. The JIDL
+format, a simple text structure, is straightforward to edit,
+making it a good format for the initial creation of a JADN model.
 
 ## E.2 Deriving Other Schemas and Serializations
 
@@ -2652,13 +2668,99 @@ simplified.
 
 > Illustration with small subset of OpenC2 language
 
+This section provide a brief example of a JADN information model,
+using data types from OpenC2. 
+
 ### E.3.1  Basic and Complex Data Types
 
 > JIDL for some basic and complex types
 
+A group of basic types and their use in the definition of an IPv4
+Connection are represented in JIDL as follows:
+
+```
+
+// An IPv4 address is a binary value representing a 32-bit integer
+
+IPv4-Addr = Binary /ipv4-addr                     // 32 bit IPv4 address as defined in [[RFC0791]](#rfc0791)
+
+
+// the IPv4-Connection type is a record
+
+IPv4-Connection = Record{1..*}                    // 5-tuple that specifies a tcp/ip connection
+   1 src_addr         IPv4-Net optional           // IPv4 source address range
+   2 src_port         Port optional               // Source service per [[RFC6335]](#rfc6335)
+   3 dst_addr         IPv4-Net optional           // IPv4 destination address range
+   4 dst_port         Port optional               // Destination service per [[RFC6335]](#rfc6335)
+   5 protocol         L4-Protocol optional        // Layer 4 protocol (e.g., TCP) - see [Section 3.4.2.10](#34210-l4-protocol)
+
+
+// the IPv4-Net type is used to represent a CIDR block
+
+IPv4-Net = Array /ipv4-net                        // IPv4 address and prefix length
+   1  IPv4-Addr                                   // ipv4_addr:: IPv4 address as defined in [[RFC0791]](#rfc0791)
+   2  Integer optional                            // prefix_length:: CIDR prefix-length. If omitted, refers to a single host address.
+
+
+// L4-Protocol is an 8-bit value therefore L4-Protocol is an enumeration from 0..255.
+// The interpretation of this value is handled through an external registry
+// See the usage requirements in Section 3.4.2.11, which also contains the following
+// commonly-used example values for the field.
+
+L4-Protocol = Enumerated                          // Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any IANA value, [[RFC5237]](#rfc5237)
+   1 icmp                                         // Internet Control Message Protocol - [[RFC0792]](#rfc0792)
+   6 tcp                                          // Transmission Control Protocol - [[RFC0793]](#rfc0793)
+  17 udp                                          // User Datagram Protocol - [[RFC0768]](#rfc0768)
+ 132 sctp                                         // Stream Control Transmission Protocol - [[RFC4960]](#rfc4960)
+
+
+// Port is a 16-bit integer
+
+Port = Integer{0..65535}                          // Transport Protocol Port Number, [[RFC6335]](#rfc6335)
+```
+
+The equivalent property table representations can be found in the
+respective section for each type (ordered as above):
+
+ - [3.4.2.9](#3429-ipv4-address): IPv4-Address
+ - [3.4.1.10](#34110-ipv4-connection): IPv4-Connection
+ - [3.4.1.9](#3419-ipv4-address-range): IPv4-Net
+ - [3.4.2.11](#34211-l4-protocol): L4-Protocol
+ - [3.4.2.15](#34215-port): Port
+ 
 ### E.3.2  JADN Representation
 
 > Corresponding JSON data in JADN format
+
+This section shows the JADN representation of the types defined
+using JIDL in the preceding section.
+
+```
+["IPv4-Addr", "Binary", ["/ipv4-addr"], "32 bit IPv4 address as defined in [[RFC0791]](#rfc0791)"],
+
+["IPv4-Connection", "Record", ["{1"], "5-tuple that specifies a tcp/ip connection", [
+    [1, "src_addr", "IPv4-Net", ["[0"], "IPv4 source address range"],
+    [2, "src_port", "Port", ["[0"], "Source service per [[RFC6335]](#rfc6335)"],
+    [3, "dst_addr", "IPv4-Net", ["[0"], "IPv4 destination address range"],
+    [4, "dst_port", "Port", ["[0"], "Destination service per [[RFC6335]](#rfc6335)"],
+    [5, "protocol", "L4-Protocol", ["[0"], "Layer 4 protocol (e.g., TCP) - see [Section 3.4.2.10](#34210-l4-protocol)"]
+]],
+
+["IPv4-Net", "Array", ["/ipv4-net"], "IPv4 address and prefix length", [
+    [1, "ipv4_addr", "IPv4-Addr", [], "IPv4 address as defined in [[RFC0791]](#rfc0791)"],
+    [2, "prefix_length", "Integer", ["[0"], "CIDR prefix-length. If omitted, refers to a single host address."]
+]],
+
+["L4-Protocol", "Enumerated", [], "Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any IANA value, [[RFC5237]](#rfc5237)", [
+    [1, "icmp", "Internet Control Message Protocol - [[RFC0792]](#rfc0792)"],
+    [6, "tcp", "Transmission Control Protocol - [[RFC0793]](#rfc0793)"],
+    [17, "udp", "User Datagram Protocol - [[RFC0768]](#rfc0768)"],
+    [132, "sctp", "Stream Control Transmission Protocol - [[RFC4960]](#rfc4960)"]
+]]
+
+["Port", "Integer", ["{0", "}65535"], "Transport Protocol Port Number, [[RFC6335]](#rfc6335)"]
+```
+
 
 ### E.3.3  Translation To JSON Schema
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2680,7 +2680,10 @@ representation, into a form that can be transmitted (i.e., into a
 "document"). JADN information models can be translated into a
 number of schemea formats, such as [[JSON schema](#json-schema)]
 or CDDL [[RFC8610](#rfc8610)], or can be used directly as a
-format-independent schema language.
+format-independent schema language. As with translation among
+JADN representations, the use of automated tools to create
+schemas ensures the schemas are an accurate, repeatable
+representation of the JADN information model.
 
 Converting an information model to a data model means applying
 serialization rules for each base type that produce physical data

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2734,16 +2734,16 @@ IPv4-Addr = Binary /ipv4-addr                     // 32 bit IPv4 address as defi
 
 IPv4-Connection = Record{1..*}                    // 5-tuple that specifies a tcp/ip connection
    1 src_addr         IPv4-Net optional           // IPv4 source address range
-   2 src_port         Port optional               // Source service per [[RFC6335]](#rfc6335)
+   2 src_port         Port optional               // Source service per [RFC6335]
    3 dst_addr         IPv4-Net optional           // IPv4 destination address range
-   4 dst_port         Port optional               // Destination service per [[RFC6335]](#rfc6335)
+   4 dst_port         Port optional               // Destination service per [RFC6335]
    5 protocol         L4-Protocol optional        // Layer 4 protocol (e.g., TCP) - see [Section 3.4.2.10](#34210-l4-protocol)
 
 
 // the IPv4-Net type is an array used to represent a CIDR block
 
 IPv4-Net = Array /ipv4-net                        // IPv4 address and prefix length
-   1  IPv4-Addr                                   // ipv4_addr:: IPv4 address as defined in [[RFC0791]](#rfc0791)
+   1  IPv4-Addr                                   // ipv4_addr:: IPv4 address as defined in [RFC0791]
    2  Integer optional                            // prefix_length:: CIDR prefix-length. If omitted, refers to a single host address.
 
 
@@ -2753,15 +2753,15 @@ IPv4-Net = Array /ipv4-net                        // IPv4 address and prefix len
 // commonly-used example values for the field.
 
 L4-Protocol = Enumerated                          // Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any IANA value, [[RFC5237]](#rfc5237)
-   1 icmp                                         // Internet Control Message Protocol - [[RFC0792]](#rfc0792)
-   6 tcp                                          // Transmission Control Protocol - [[RFC0793]](#rfc0793)
-  17 udp                                          // User Datagram Protocol - [[RFC0768]](#rfc0768)
- 132 sctp                                         // Stream Control Transmission Protocol - [[RFC4960]](#rfc4960)
+   1 icmp                                         // Internet Control Message Protocol - [RFC0792]
+   6 tcp                                          // Transmission Control Protocol - [RFC0793]
+  17 udp                                          // User Datagram Protocol - [RFC0768]
+ 132 sctp                                         // Stream Control Transmission Protocol - [RFC4960]
 
 
 // Port is a 16-bit integer
 
-Port = Integer{0..65535}                          // Transport Protocol Port Number, [[RFC6335]](#rfc6335)
+Port = Integer{0..65535}                          // Transport Protocol Port Number, [RFC6335]
 ```
 
 The equivalent property table representations can be found in the

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2643,8 +2643,6 @@ good format for the initial creation of a JADN model.
 
 ## E.2 Deriving Other Schemas and Serializations
 
-> Explanation how JADN schema enables other schemas & serializations
-
 Converting an information model to a data model means applying
 serialization rules for each base type that produce physical data
 in the desired format. Serialization is the process for
@@ -2666,14 +2664,10 @@ simplified.
 
 ## E.3 JADN Example: OpenC2 Subset
 
-> Illustration with small subset of OpenC2 language
-
 This section provide a brief example of a JADN information model,
 using data types from OpenC2. 
 
 ### E.3.1  Basic and Complex Data Types
-
-> JIDL for some basic and complex types
 
 A 5-tuple is a common means of representing a TCP or UDP session,
 providing the source and destination IP addresses and ports, and
@@ -2734,8 +2728,6 @@ respective section for each type (ordered as above):
  - [3.4.2.15](#34215-port): Port
  
 ### E.3.2  JADN Representation
-
-> Corresponding JSON data in JADN format
 
 This section shows the JADN representation of the types defined
 using JIDL in the preceding section.

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2676,7 +2676,7 @@ using data types from OpenC2.
 > JIDL for some basic and complex types
 
 A 5-tuple is a common means of representing a TCP or UDP session,
-providing the source and destionation IP addresses and ports, and
+providing the source and destination IP addresses and ports, and
 identifying the Layer 4 protocol in use. The corresponding OpenC2
 target type is called an `IPv4-Connection` (see section
 [3.4.1.10](#34110-ipv4-connection)).  A group of basic types and

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2615,6 +2615,7 @@ Reference to OpenC2 JADN schema external artifact
 | Issue #393 | 8/2/2022 | Lemire | * Change ArrayOf() to multiplicity where possible |
 | Issue #396 | 8/xx/2022 | Lemire | * Fixed malformed table in 3.4.2.1 <br> * Reordered data types alphabetically  |
 | Administrative | 9/07/2022 | Lemire | Changes for version update, v1.1 to v2.0  |
+| Issue #361 | 9/xx/2022 | Lemire | Add explanatory JADN appendix  |
 
 
 # Appendix G. Acknowledgments

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2570,9 +2570,13 @@ the "Target" data type.
 
 *The content in this section is non-normative.*
 
-This appendix provides a brief overview of the *JSON Abstract Data
-Notation (JADN)* [[JADN-v1.0](#jadn-v10)] information modeling (IM) language
-and its application to rigorously specifying the OpenC2 language.
+This appendix provides a brief overview of the *JSON Abstract
+Data Notation (JADN)* [[JADN-v1.0](#jadn-v10)] information
+modeling (IM) language and its application to rigorously
+specifying the OpenC2 language. Unless explicitly labeled
+otherwise, section references in this appendix are to section of
+the [JADN](#jadn-v10) specification, rather than this
+language specification.
 
 ## E.1 JADN Overview
 
@@ -2583,7 +2587,7 @@ describes it as follows:
 > modeling language that defines data structure independently of
 > data format. 
 
-As the specification explains:  [RFC 3444](#rfc3444),
+As the specification explains (section 1):  [RFC 3444](#rfc3444),
 "Information Models and Data Models", notes that the main purpose
 of an **information model** is to model objects at a conceptual
 level, independent of specific implementations or protocols used
@@ -2607,7 +2611,7 @@ JADN defines a set of base types that includes five "primitives
 map, record). JADN type definitions have a fixed structure
 designed to be easily describable, easily processed, stable, and
 extensible. Every definition in a JADN document is described in
-terms of five elements: 
+terms of five elements (JADN specifcation section 3.1): 
 
 1) **TypeName:** the name of the type being defined
 2) **BaseType:** the JADN predefined type (Table 3-1) of the type
@@ -2619,10 +2623,11 @@ terms of five elements:
 
 From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
-representations. A rich set of options (e.g., semantic validation,
-size and value contstraints, multiplicity constraints) provide
-the means to define a wide variety of information types in a
-representation-independent manner.
+representations. Section 3.2 describes a rich set of options
+(e.g., semantic validation, size and value contstraints,
+multiplicity constraints) provide the means to define a wide
+variety of information types in a representation-independent
+manner.
 
 The native format of JADN is JSON, but JADN content can be
 represented in others ways that are more useful for
@@ -2649,7 +2654,8 @@ in the desired format. Serialization is the process for
 converting application information, regardless of its internal
 representation, into a form that can be transmitted (i.e., into a
 "document"). The JADN specification defines serialization rules
-for four different representations of an information model:
+for four different representations of an information mode
+(Section 4):
 
  - Verbose JSON
  - Compact JSON
@@ -2658,9 +2664,9 @@ for four different representations of an information model:
 
 In addition, the specification identifies the constraints that
 must be satisifed to define how a JADN IM is represented in other
-serializations. Because each serialization represents the same
-information model, translation between serialization formats is
-simplified.
+serializations (Section 4). Because each serialization represents
+the same information model, translation between serialization
+formats is simplified.
 
 ## E.3 JADN Example: OpenC2 Subset
 
@@ -2673,9 +2679,9 @@ A 5-tuple is a common means of representing a TCP or UDP session,
 providing the source and destination IP addresses and ports, and
 identifying the Layer 4 protocol in use. The corresponding OpenC2
 target type is called an `IPv4-Connection` (see section
-[3.4.1.10](#34110-ipv4-connection)).  A group of basic types and
-their use in the specification of an IPv4 Connection information
-model are represented in JIDL as follows:
+[3.4.1.10](#34110-ipv4-connection) of this specification).  A
+group of basic types and their use in the definition of an IPv4
+Connection information model are represented in JIDL as follows:
 
 ```
 
@@ -2719,9 +2725,10 @@ Port = Integer{0..65535}                          // Transport Protocol Port Num
 ```
 
 The equivalent property table representations can be found in the
-respective section for each type (ordered as above):
+respective section of this specification for each type (ordered
+as above):
 
- - [3.4.2.9](#3429-ipv4-address): IPv4-Address
+ - [3.4.2.9](#3429-ipv4-address): IPv4-Addr
  - [3.4.1.10](#34110-ipv4-connection): IPv4-Connection
  - [3.4.1.9](#3419-ipv4-address-range): IPv4-Net
  - [3.4.2.11](#34211-l4-protocol): L4-Protocol

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2738,7 +2738,7 @@ IPv4-Connection = Record{1..*}                    // 5-tuple that specifies a tc
    5 protocol         L4-Protocol optional        // Layer 4 protocol (e.g., TCP) - see [Section 3.4.2.10](#34210-l4-protocol)
 
 
-// the IPv4-Net type is used to represent a CIDR block
+// the IPv4-Net type is an array used to represent a CIDR block
 
 IPv4-Net = Array /ipv4-net                        // IPv4 address and prefix length
    1  IPv4-Addr                                   // ipv4_addr:: IPv4 address as defined in [[RFC0791]](#rfc0791)

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2540,13 +2540,17 @@ the "Action-Targets" data type should be an enumerated list of the possible
 Targets
 
 **Definition of "Action-Targets" Data Type:** The Targets data type is defined
-as an array of "Target" enumerations. The "Target" enumerations are derived from
-the "Target" data type.
+as an array of "Target" enumerations. 
 
 | Type Name          | Type Definition              | Description                                                                                             |
 |--------------------|------------------------------|---------------------------------------------------------------------------------------------------------|
 | **Action-Targets** | MapOf(Action, Targets)       | Map of each action supported by each Actuator Profile to the list of targets applicable to that action. |
+
+The "Target" enumerations are derived from
+the "Target" data type.
+
 | Type Name          | Type Definition              | Description                                                                                             |
+|--------------------|------------------------------|---------------------------------------------------------------------------------------------------------|
 | **Targets**        | ArrayOf(Enum(Target)){1..\*} | List of Target fields                                                                                   |
 
 **Example:** The "pairs" property is defined as an "Action-Targets" data type.

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2563,6 +2563,43 @@ the "Target" data type.
 
 *The content in this section is non-normative.*
 
+## E.1 JADN Overview
+
+JADN as an Information Modeling (IM) language
+
+## E.2 Deriving Other Schemas and Serializations
+
+Explanation how JADN schema enables other schemas & serializations
+
+## E.3 JADN Example: OpenC2 Subset
+
+Illustration with small subset of OpenC2 language
+
+### E.3.1  Basic and Complex Data Types
+
+JIDL for some basic and complex types
+
+### E.3.2  JADN Representation
+
+Corresponding JSON data in JADN format
+
+### E.3.3  Translation To JSON Schema
+
+JADN translation to JSON schema
+
+### E.3.4  Translation to CBOR / CDDL
+
+JADN translation to CBOR/CDDL
+
+## E.5 Additional Information
+
+Reference to OpenC2 JADN schema external artifact
+
+
+
+
+
+
 # Appendix F. Revision History
 
 *The content in this section is non-normative.*

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2675,8 +2675,13 @@ using data types from OpenC2.
 
 > JIDL for some basic and complex types
 
-A group of basic types and their use in the definition of an IPv4
-Connection are represented in JIDL as follows:
+A 5-tuple is a common means of representing a TCP or UDP session,
+providing the source and destionation IP addresses and ports, and
+identifying the Layer 4 protocol in use. The corresponding OpenC2
+target type is called an `IPv4-Connection` (see section
+[3.4.1.10](#34110-ipv4-connection)).  A group of basic types and
+their use in the specification of an IPv4 Connection information
+model are represented in JIDL as follows:
 
 ```
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2524,58 +2524,6 @@ NrWYJty9TObjiPcu3ZvkE/JCWhD3W1/YPZX6DN5TFZpR2A==
 -----END PUBLIC KEY-----
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Appendix D. Design Elements
-
-## D.1 Derived Enumerations
-
-It is sometimes useful to reference the fields of a structure definition, for
-example to list fields that are usable in a particular context, or to read or
-update the value of a specific field. An instance of a reference can be
-validated against the set of valid references using either an explicit or a
-derived Enumerated type. A derived enumeration is created using an Enum()
-expression on the type being referenced, and it results in an Enumerated type
-containing the ID and Name columns of the referenced type.
-
-This is the design element that defines the "Action-Targets" data type. The
-"Action-Targets" data type is a map of each action supported by an actuator to a
-list of targets implemented for each action. The list of Actions, defined in
-[Section 3.3.1.1](#3311-action), is appropriately an enumerated list of possible
-Actions. The list of Targets, defined in [Section 3.3.1.2](#3312-target), is a
-Choice data structure where each element is a complex data type of its own. A
-derived enumeration is used in this case to signify that the list of Targets for
-the "Action-Targets" data type should be an enumerated list of the possible
-Targets
-
-**Definition of "Action-Targets" Data Type:** The Targets data type is defined
-as an array of "Target" enumerations. 
-
-| Type Name          | Type Definition              | Description                                                                                             |
-|--------------------|------------------------------|---------------------------------------------------------------------------------------------------------|
-| **Action-Targets** | MapOf(Action, Targets)       | Map of each action supported by each Actuator Profile to the list of targets applicable to that action. |
-
-The "Target" enumerations are derived from
-the "Target" data type.
-
-| Type Name          | Type Definition              | Description                                                                                             |
-|--------------------|------------------------------|---------------------------------------------------------------------------------------------------------|
-| **Targets**        | ArrayOf(Enum(Target)){1..\*} | List of Target fields                                                                                   |
-
-**Example:** The "pairs" property is defined as an "Action-Targets" data type.
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-{
-    "status": 200,
-    "results": {
-        "pairs": {
-            "allow": ["ipv6_net", "ipv6_connection"],
-            "deny": ["ipv6_net", "ipv6_connection"],
-            "query": ["features"],
-            "delete": ["slpf:rule_number"],
-            "update": ["file"]
-        }
-    }
-}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Appendix E. Schema Development With JADN
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2629,9 +2629,19 @@ From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
 representations. Section 3.2 describes a rich set of options
 (e.g., semantic validation, size and value contstraints,
-multiplicity constraints) provide the means to define a wide
+multiplicity constraints) that provide the means to define a wide
 variety of information types in a representation-independent
 manner.
+
+As an information modeling language, JADN supports only two kinds
+of relationships: "contain" and "reference".  A JADN information
+model is a set of type definitions, where each definition may be
+basic or structured. Each field in a structured type may be
+associated with another model-defined type, and the set of
+associations between types forms a directed graph. Each
+association is either a container or a reference, and the
+direction of each edge is toward the contained or referenced
+type.
 
 The native format of JADN is JSON, but JADN content can be
 represented in others ways that are more useful for

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2718,8 +2718,10 @@ destination IP addresses and ports, and identifying the Layer 4
 protocol in use. The corresponding OpenC2 target type is called
 an `IPv4-Connection` (see section
 [3.4.1.10](#34110-ipv4-connection) of this specification).  A
-group of basic types and their use in the definition of an IPv4
-Connection information model are represented in JIDL as follows:
+group of basic (i.e., binary, integer) and complex (i.e., record,
+array, enumeration) types and their use in the definition of an
+IPv4 Connection information model are represented in JIDL as
+follows:
 
 ```
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2657,10 +2657,12 @@ representation, into a form that can be transmitted (i.e., into a
 for four different representations of an information mode
 (Section 4):
 
- - Verbose JSON
- - Compact JSON
- - Concise JSON
- - CBOR
+| Serialization Type |                              Description                              |
+|:------------------:|:---------------------------------------------------------------------:|
+|    Verbose JSON    | Human-readable JSON format using name-value encoding for tabular data |
+|    Compact JSON    | Human-readable JSON format using positional encoding for tabular data |
+|    Concise JSON    | Represents JADN data types in a format optimized for minimum size     |
+|        CBOR        | Concise Binary Object Representation format of JADN types             |
 
 In addition, the specification identifies the constraints that
 must be satisifed to define how a JADN IM is represented in other

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2764,12 +2764,16 @@ using JIDL in the preceding section.
 
 ### D.3.3  Translation To JSON Schema
 
-> JADN translation to JSON schema
+> TBD:  JADN translation to JSON schema
 
 ## D.4 Additional Information
 
-> Reference to OpenC2 JADN schema external artifact
+JADN supports organizing features to facilitate the creation and management of JADN schemas. In particular:
 
+ - Schemas can be broken up into a collection of **packages**. A package is a collection of type definitions along with information about the package, such as the namespace the package defines, its version, and other administrative and technical information.
+ - The use of **namespaces** enables one packages toi reference type definitions from other packages.
+
+> TBD: Reference to, descriptionf of OpenC2 JADN schema external artifact
 
 
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2662,14 +2662,21 @@ good format for the initial creation of a JADN model.
 
 ## E.2 Deriving Other Schemas and Serializations
 
-Converting an information model to a data model means applying
-serialization rules for each base type that produce physical data
-in the desired format. Serialization is the process for
+Once the information model is developed, its use in applications
+requires serialization and deserialization of the information in
+some specific format to permit transmisssion or storage of the
+data corresponding to the model. Serialization is the process for
 converting application information, regardless of its internal
 representation, into a form that can be transmitted (i.e., into a
-"document"). The JADN specification defines serialization rules
-for four different representations of an information mode
-(Section 4):
+"document"). JADN information models can be translated into a
+number of schemea formats, such as JSON schema or CDDL, or can be
+used directly as a format-independent schema language.
+
+Converting an information model to a data model means applying
+serialization rules for each base type that produce physical data
+in the desired format.  The JADN specification defines
+serialization rules for four different representations of an
+information mode (Section 4):
 
 | Serialization Type |                              Description                              |
 |:------------------:|:---------------------------------------------------------------------:|

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2584,8 +2584,8 @@ terms of five elements (JADN specification section 3.1):
 
 From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
-representations. Section 3.2 describes a rich set of options
-(e.g., semantic validation, size and value constraints,
+representations. Section 3.2 describes an extensive set of
+options (e.g., semantic validation, size and value constraints,
 multiplicity constraints) that provide the means to define a wide
 variety of information types in a representation-independent
 manner.

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2740,6 +2740,14 @@ as above):
  - [3.4.2.11](#34211-l4-protocol): L4-Protocol
  - [3.4.2.15](#34215-port): Port
  
+The example above also makes use of a pair of  JADN semantic
+validation keywords: `"ipv4-addr"` and `"ipv4-net"` (see section
+3.2.1.5 of the [JADN](#jadn-v10) specification). These keywords
+specify validation requirements for the data types where they are
+used. For example, "`ipv4-addr"` is used to force the
+representation of a binary address in "dotted quad"
+representation, per [[RFC 791](#rfc0791)].
+
 ### E.3.2  JADN Representation
 
 This section shows the JADN representation of the types defined

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2063,6 +2063,9 @@ RFC 2119, DOI 10.17487/RFC2119, March 1997,
 Crawford, M., *"Binary Labels in the Domain Name System"*, RFC 2673, August
 1999, https://tools.ietf.org/html/rfc2673
 
+###### [RFC3444] 
+Pras, A., Schoenwaelder, J., "On the Difference between Information Models and Data Models", RFC 3444, January 2003, https://tools.ietf.org/html/rfc3444.
+
 ###### [RFC3986]
 
 Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform Resource Identifier
@@ -2567,13 +2570,68 @@ the "Target" data type.
 
 *The content in this section is non-normative.*
 
+This appendix provides a brief overview of the *JSON Abstract Data
+Notation (JADN)* [[JADN-v1.0](#jadn-v10)] information modeling (IM) language
+and its application to rigorously specifying the OpenC2 language.
+
 ## E.1 JADN Overview
 
-JADN as an Information Modeling (IM) language
+> JADN as an Information Modeling (IM) language
+
+The abstract of the OASIS Committee Specification for JADN
+describes it as follows:
+
+> JSON Abstract Data Notation (JADN) is a UML-based information
+> modeling language that defines data structure independently of
+> data format. 
+
+As the specification explains:  [RFC 3444](#rfc3444),
+"Information Models and Data Models", notes that the main purpose
+of an information model is to model objects at a conceptual
+level, independent of specific implementations or protocols used
+to transport the data. JADN provides a tool for developing
+information models, which can be used to define and generate
+physical data models, validate information instances, and enable
+lossless translation across data formats. 
+
+A JADN specification consists of type definitions that comprise
+the information model, and serialization rules that define how
+information instances are represented as data. The model is
+documented using a compact and expressive interface definition
+language, property tables, or entity relationship diagrams,
+easing integration with existing design processes and
+architecture tools.
+
+JADN defines a set of base types that includes five "primitives
+(e.g., boolean, string), and seven complex types (e.g., array,
+map, record). JADN type definitions have a fixed structure
+designed to be easily describable, easily processed, stable, and
+extensible. Every definition in a JADN document is described in
+terms of five elements: 
+
+1) **TypeName:** the name of the type being defined
+1) **BaseType:** the JADN predefined type (Table 3-1) of the type
+   being defined
+1) **TypeOptions:** an array of zero or more TypeOption (Section
+   3.2.1) applicable to BaseType
+1) **TypeDescription:** a non-normative comment
+1) **Fields:** an array of Item or Field definitions
+
+From this starting point JADN enables creation of a rich
+information model readily expressed in any of several
+representations. A rich set of options (e.g., semanic validation,
+size and value contstraints, multiplicity constraints) provide
+the means to define a wide variety of information types in a
+representation-independent manner.
+
 
 ## E.2 Deriving Other Schemas and Serializations
 
-Explanation how JADN schema enables other schemas & serializations
+> Explanation how JADN schema enables other schemas & serializations
+
+
+
+
 
 ## E.3 JADN Example: OpenC2 Subset
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2646,7 +2646,7 @@ type.
 The native format of JADN is JSON, but JADN content can be
 represented in others ways that are more useful for
 documentation. The [JADN Specification](#jadn-v10) identifies
-three formats (Section 5):
+three formats (Section 5) in addition to the native format:
 
  - JADN Interface Definition Language (JIDL)
  - Table Style 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2637,10 +2637,10 @@ representation, into a form that can be transmitted (i.e., into a
 "document"). The JADN specification defines serialization rules
 for four different representations of an information model:
 
- - Verbose JSON serialization
- - Compact JSON serialization
- - Concise JSON serialization
- - CBOR serialization
+ - Verbose JSON
+ - Compact JSON
+ - Concise JSON
+ - CBOR
 
 In addition, the specification identifies the constraints that
 must be satisifed to define how a JADN IM is represented in other

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2650,27 +2650,27 @@ simplified.
 
 ## E.3 JADN Example: OpenC2 Subset
 
-Illustration with small subset of OpenC2 language
+> Illustration with small subset of OpenC2 language
 
 ### E.3.1  Basic and Complex Data Types
 
-JIDL for some basic and complex types
+> JIDL for some basic and complex types
 
 ### E.3.2  JADN Representation
 
-Corresponding JSON data in JADN format
+> Corresponding JSON data in JADN format
 
 ### E.3.3  Translation To JSON Schema
 
-JADN translation to JSON schema
+> JADN translation to JSON schema
 
 ### E.3.4  Translation to CBOR / CDDL
 
-JADN translation to CBOR/CDDL
+> JADN translation to CBOR/CDDL
 
 ## E.5 Additional Information
 
-Reference to OpenC2 JADN schema external artifact
+> Reference to OpenC2 JADN schema external artifact
 
 
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2624,12 +2624,14 @@ designed to be easily describable, easily processed, stable, and
 extensible. Every definition in a JADN document is described in
 terms of five elements (JADN specification section 3.1): 
 
-1) **TypeName:** the name of the type being defined
-2) **BaseType:** the JADN predefined type (Table 3-1) of the type
-   being defined
+1) **TypeName:** a stromg containing the name of the type being
+   defined
+2) **BaseType:** a choice from the JADN predefined types (Table
+   3-1) of the type being defined
 3) **TypeOptions:** an array of zero or more TypeOption (Section
    3.2.1) applicable to BaseType
-4) **TypeDescription:** a non-normative comment
+4) **TypeDescription:** a stromg containing a non-normative
+   comment
 5) **Fields:** an array of Item or Field definitions
 
 From this starting point JADN enables creation of a rich

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2672,7 +2672,7 @@ data corresponding to the model. Serialization is the process for
 converting application information, regardless of its internal
 representation, into a form that can be transmitted (i.e., into a
 "document"). JADN information models can be translated into a
-number of schemea formats, such as JSON schema or CDDL, or can be
+number of schemea formats, such as [[JSON schema](#json-schema)] or CDDL, or can be
 used directly as a format-independent schema language.
 
 Converting an information model to a data model means applying

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2629,9 +2629,24 @@ representation-independent manner.
 
 > Explanation how JADN schema enables other schemas & serializations
 
+Converting an information model to a data model means applying
+serialization rules for each base type that produce physical data
+in the desired format. Serialization is the process for
+converting application information, regardless of its internal
+representation, into a form that can be transmitted (i.e., into a
+"document"). The JADN specification defines serialization rules
+for four different representations of an information model:
 
+ - Verbose JSON serialization
+ - Compact JSON serialization
+ - Concise JSON serialization
+ - CBOR serialization
 
-
+In addition, the specification identifies the constraints that
+must be satisifed to define how a JADN IM is represented in other
+serializations. Because each serialization represents the same
+information model, translation between serialization formats is
+simplified.
 
 ## E.3 JADN Example: OpenC2 Subset
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2711,10 +2711,12 @@ using data types from OpenC2.
 
 ### E.3.1  Basic and Complex Data Types
 
-A 5-tuple is a common means of representing a TCP or UDP session,
-providing the source and destination IP addresses and ports, and
-identifying the Layer 4 protocol in use. The corresponding OpenC2
-target type is called an `IPv4-Connection` (see section
+This example illustrates the use of basic and complex types to
+describe a network connection. A 5-tuple is a common means of
+representing a TCP or UDP session, recording the source and
+destination IP addresses and ports, and identifying the Layer 4
+protocol in use. The corresponding OpenC2 target type is called
+an `IPv4-Connection` (see section
 [3.4.1.10](#34110-ipv4-connection) of this specification).  A
 group of basic types and their use in the definition of an IPv4
 Connection information model are represented in JIDL as follows:

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2222,6 +2222,10 @@ Rescorla, E. and B. Korver, "Guidelines for Writing RFC Text on Security
 Considerations", BCP 72, RFC 3552, DOI 10.17487/RFC3552, July 2003,
 https://www.rfc-editor.org/info/rfc3552.
 
+###### [RFC8610]
+
+Birkholz, H., Vigano, C. and Bormann, C., "Concise Data Definition Language (CDDL): A Notational Convention to Express Concise Binary Object Representation (CBOR) and JSON Data Structures", RFC 8610, DOI 10.17487/RFC8610, June 2019, https://www.rfc-editor.org/info/rfc8610
+
 ###### [IACD]
 
 "What is IACD", __IACD__, Integrated Adaptive Cyber Defense, 3/17/2018, https://www.iacdautomate.org/

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2626,7 +2626,7 @@ data corresponding to the model. Serialization is the process for
 converting application information, regardless of its internal
 representation, into a form that can be transmitted (i.e., into a
 "document"). JADN information models can be translated into a
-number of schemea formats, such as [[JSON schema](#json-schema)]
+number of schema formats, such as [[JSON schema](#json-schema)]
 or CDDL [[RFC8610](#rfc8610)], or can be used directly as a
 format-independent schema language. As with translation among
 JADN representations, the use of automated tools to create

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2624,13 +2624,13 @@ designed to be easily describable, easily processed, stable, and
 extensible. Every definition in a JADN document is described in
 terms of five elements (JADN specification section 3.1): 
 
-1) **TypeName:** a stromg containing the name of the type being
+1) **TypeName:** a string containing the name of the type being
    defined
 2) **BaseType:** a choice from the JADN predefined types (Table
    3-1) of the type being defined
 3) **TypeOptions:** an array of zero or more TypeOption (Section
    3.2.1) applicable to BaseType
-4) **TypeDescription:** a stromg containing a non-normative
+4) **TypeDescription:** a string containing a non-normative
    comment
 5) **Fields:** an array of Item or Field definitions
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2727,8 +2727,8 @@ validation keywords: `"ipv4-addr"` and `"ipv4-net"`. These
 keywords specify validation requirements for the data types where
 they are used (see section 3.2.1.5 of the [JADN](#jadn-v10)
 specification). For example, "`ipv4-addr"` is used to force the
-representation of a binary address in "dotted quad"
-representation, per [[RFC 791](#rfc0791)].
+representation of a binary address in the commonly used "dotted
+quad" format.
 
 ### D.3.2  JADN Representation
 
@@ -2766,7 +2766,7 @@ using JIDL in the preceding section.
 
 > JADN translation to JSON schema
 
-## D.5 Additional Information
+## D.4 Additional Information
 
 > Reference to OpenC2 JADN schema external artifact
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2559,7 +2559,11 @@ the "Target" data type.
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Appendix E. Revision History
+# Appendix E. Schema Development With JADN
+
+*The content in this section is non-normative.*
+
+# Appendix F. Revision History
 
 *The content in this section is non-normative.*
 
@@ -2576,7 +2580,7 @@ the "Target" data type.
 | Administrative | 9/07/2022 | Lemire | Changes for version update, v1.1 to v2.0  |
 
 
-# Appendix F. Acknowledgments
+# Appendix G. Acknowledgments
 
 *The content in this section is non-normative.*
 
@@ -2647,7 +2651,7 @@ specification and are gratefully acknowledged:
 | Sounil     | Yu            | Bank of America                                                      |
 | Vasileios  | Mavroeidis    | University of Oslo                                                   |
 
-# Appendix G. Notices
+# Appendix H. Notices
 
 Copyright © OASIS Open 2021. All Rights Reserved.
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2005,6 +2005,10 @@ publication, OASIS cannot guarantee their long-term validity.
 The following documents are referenced in such a way that some or all of their
 content constitutes requirements of this document.
 
+###### [JADN-v1.0]
+
+JSON Abstract Data Notation Version 1.0. Edited by David Kemp. 17 August 2021. OASIS Committee Specification 01. https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html. Latest stage: https://docs.oasis-open.org/openc2/jadn/v1.0/jadn-v1.0.html.
+
 ###### [OpenC2-HTTPS-v1.0]
 
 *Specification for Transfer of OpenC2 Messages via HTTPS Version 1.0*. Edited by

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2574,9 +2574,9 @@ This appendix provides a brief overview of the *JSON Abstract
 Data Notation (JADN)* [[JADN-v1.0](#jadn-v10)] information
 modeling (IM) language and its application to rigorously
 specifying the OpenC2 language. Unless explicitly labeled
-otherwise, section references in this appendix are to section of
-the [JADN](#jadn-v10) specification, rather than this
-language specification.
+otherwise, section references in this appendix are to sections of
+the [JADN](#jadn-v10) specification, rather than this language
+specification.
 
 ## E.1 JADN Overview
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2617,7 +2617,7 @@ definition language, property tables, or entity relationship
 diagrams, easing integration with existing design processes and
 architecture tools.
 
-JADN defines a set of base types that includes five "primitives
+JADN defines a set of base types that includes five "primitives"
 (e.g., boolean, string), and seven complex types (e.g., array,
 map, record). JADN type definitions have a fixed structure
 designed to be easily describable, easily processed, stable, and

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2579,8 +2579,8 @@ Data Notation (JADN)* [[JADN-v1.0](#jadn-v10)] information
 modeling (IM) language and its application to rigorously
 specifying the OpenC2 language. Unless explicitly labeled
 otherwise, section references in this appendix are to sections of
-the [JADN](#jadn-v10) specification, rather than this language
-specification.
+the [JADN](#jadn-v10) specification, rather than this Language
+Specification.
 
 ## E.1 JADN Overview
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2619,7 +2619,7 @@ terms of five elements:
 
 From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
-representations. A rich set of options (e.g., semanic validation,
+representations. A rich set of options (e.g., semantic validation,
 size and value contstraints, multiplicity constraints) provide
 the means to define a wide variety of information types in a
 representation-independent manner.

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2576,8 +2576,6 @@ and its application to rigorously specifying the OpenC2 language.
 
 ## E.1 JADN Overview
 
-> JADN as an Information Modeling (IM) language
-
 The abstract of the OASIS Committee Specification for JADN
 describes it as follows:
 
@@ -2587,19 +2585,21 @@ describes it as follows:
 
 As the specification explains:  [RFC 3444](#rfc3444),
 "Information Models and Data Models", notes that the main purpose
-of an information model is to model objects at a conceptual
+of an **information model** is to model objects at a conceptual
 level, independent of specific implementations or protocols used
 to transport the data. JADN provides a tool for developing
 information models, which can be used to define and generate
 physical data models, validate information instances, and enable
 lossless translation across data formats. 
 
-A JADN specification consists of type definitions that comprise
-the information model, and serialization rules that define how
-information instances are represented as data. The model is
-documented using a compact and expressive interface definition
-language, property tables, or entity relationship diagrams,
-easing integration with existing design processes and
+A JADN specification consists of:
+ -  type definitions that comprise the information model, and
+ -  serialization rules that define how information instances are
+    represented as data. 
+
+The model is documented using a compact and expressive interface
+definition language, property tables, or entity relationship
+diagrams, easing integration with existing design processes and
 architecture tools.
 
 JADN defines a set of base types that includes five "primitives
@@ -2610,12 +2610,12 @@ extensible. Every definition in a JADN document is described in
 terms of five elements: 
 
 1) **TypeName:** the name of the type being defined
-1) **BaseType:** the JADN predefined type (Table 3-1) of the type
+2) **BaseType:** the JADN predefined type (Table 3-1) of the type
    being defined
-1) **TypeOptions:** an array of zero or more TypeOption (Section
+3) **TypeOptions:** an array of zero or more TypeOption (Section
    3.2.1) applicable to BaseType
-1) **TypeDescription:** a non-normative comment
-1) **Fields:** an array of Item or Field definitions
+4) **TypeDescription:** a non-normative comment
+5) **Fields:** an array of Item or Field definitions
 
 From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
@@ -2638,8 +2638,8 @@ four of these formats. Table style presentation is often used in
 specifications (e.g., as property tables such as are found in the
 body of this specficiation). Entity relationship diagrams are
 helpful for visualization of an information model. The JIDL
-format, a simple text structure, is straightforward to edit,
-making it a good format for the initial creation of a JADN model.
+format, a simple text structure, is easy to edit, making it a
+good format for the initial creation of a JADN model.
 
 ## E.2 Deriving Other Schemas and Serializations
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2741,10 +2741,10 @@ as above):
  - [3.4.2.15](#34215-port): Port
  
 The example above also makes use of a pair of  JADN semantic
-validation keywords: `"ipv4-addr"` and `"ipv4-net"` (see section
-3.2.1.5 of the [JADN](#jadn-v10) specification). These keywords
-specify validation requirements for the data types where they are
-used. For example, "`ipv4-addr"` is used to force the
+validation keywords: `"ipv4-addr"` and `"ipv4-net"`. These
+keywords specify validation requirements for the data types where
+they are used (see section 3.2.1.5 of the [JADN](#jadn-v10)
+specification). For example, "`ipv4-addr"` is used to force the
 representation of a binary address in "dotted quad"
 representation, per [[RFC 791](#rfc0791)].
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2637,7 +2637,7 @@ terms of five elements (JADN specification section 3.1):
 From this starting point JADN enables creation of a rich
 information model readily expressed in any of several
 representations. Section 3.2 describes a rich set of options
-(e.g., semantic validation, size and value contstraints,
+(e.g., semantic validation, size and value constraints,
 multiplicity constraints) that provide the means to define a wide
 variety of information types in a representation-independent
 manner.
@@ -2664,7 +2664,7 @@ three formats (Section 5) in addition to the native format:
 Automated tooling makes it straightforward to translate among all
 four of these formats. Table style presentation is often used in
 specifications (e.g., as property tables such as are found in the
-body of this specficiation). Entity relationship diagrams are
+body of this specification). Entity relationship diagrams are
 helpful for visualization of an information model. The JIDL
 format, a simple text structure, is easy to edit, making it a
 good format for the initial creation of a JADN model.

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -2788,29 +2788,29 @@ This section shows the JADN representation of the types defined
 using JIDL in the preceding section.
 
 ```
-["IPv4-Addr", "Binary", ["/ipv4-addr"], "32 bit IPv4 address as defined in [[RFC0791]](#rfc0791)"],
+["IPv4-Addr", "Binary", ["/ipv4-addr"], "32 bit IPv4 address as defined in [RFC0791]"],
 
 ["IPv4-Connection", "Record", ["{1"], "5-tuple that specifies a tcp/ip connection", [
     [1, "src_addr", "IPv4-Net", ["[0"], "IPv4 source address range"],
-    [2, "src_port", "Port", ["[0"], "Source service per [[RFC6335]](#rfc6335)"],
+    [2, "src_port", "Port", ["[0"], "Source service per [RFC6335],
     [3, "dst_addr", "IPv4-Net", ["[0"], "IPv4 destination address range"],
-    [4, "dst_port", "Port", ["[0"], "Destination service per [[RFC6335]](#rfc6335)"],
-    [5, "protocol", "L4-Protocol", ["[0"], "Layer 4 protocol (e.g., TCP) - see [Section 3.4.2.10](#34210-l4-protocol)"]
+    [4, "dst_port", "Port", ["[0"], "Destination service per [RFC6335],
+    [5, "protocol", "L4-Protocol", ["[0"], "Layer 4 protocol (e.g., TCP) - see Section 3.4.2.10"]
 ]],
 
 ["IPv4-Net", "Array", ["/ipv4-net"], "IPv4 address and prefix length", [
-    [1, "ipv4_addr", "IPv4-Addr", [], "IPv4 address as defined in [[RFC0791]](#rfc0791)"],
+    [1, "ipv4_addr", "IPv4-Addr", [], "IPv4 address as defined in [RFC0791],
     [2, "prefix_length", "Integer", ["[0"], "CIDR prefix-length. If omitted, refers to a single host address."]
 ]],
 
 ["L4-Protocol", "Enumerated", [], "Value of the protocol (IPv4) or next header (IPv6) field in an IP packet. Any IANA value, [[RFC5237]](#rfc5237)", [
-    [1, "icmp", "Internet Control Message Protocol - [[RFC0792]](#rfc0792)"],
-    [6, "tcp", "Transmission Control Protocol - [[RFC0793]](#rfc0793)"],
-    [17, "udp", "User Datagram Protocol - [[RFC0768]](#rfc0768)"],
-    [132, "sctp", "Stream Control Transmission Protocol - [[RFC4960]](#rfc4960)"]
+    [1, "icmp", "Internet Control Message Protocol - [RFC0792],
+    [6, "tcp", "Transmission Control Protocol - [RFC0793],
+    [17, "udp", "User Datagram Protocol - [RFC0768],
+    [132, "sctp", "Stream Control Transmission Protocol - [RFC4960]"]
 ]]
 
-["Port", "Integer", ["{0", "}65535"], "Transport Protocol Port Number, [[RFC6335]](#rfc6335)"]
+["Port", "Integer", ["{0", "}65535"], "Transport Protocol Port Number, [RFC6335]"]
 ```
 
 


### PR DESCRIPTION
This PR partially responds to issue #361 by providing a new non-normative appendix to illustrate how JADN can be applied to define the OpenC2 information model, and how the JADN definition then supports creating derivative schemas in various formats.