### PR TITLE
Add Jason Romano back as editor

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -43,7 +43,7 @@ Michael Rosa (mjrosa@nsa.gov), [National Security Agency](https://www.nsa.gov)
 Duncan Sparrell (duncan@sfractal.com), [sFractal Consulting
 LLC](http://www.sfractal.com/)\
 Toby Considine (toby.considine@unc.edu), [University of North Carolina at Chapel Hill](https://www.unc.edu/)\
-Jason Romano, [National Security Agency](https://www.nsa.gov/) \
+Jason Romano, [National Security Agency](https://www.nsa.gov/)
 
 #### Abstract:
 

--- a/oc2ls.md
+++ b/oc2ls.md
@@ -41,9 +41,9 @@ Michael Rosa (mjrosa@nsa.gov), [National Security Agency](https://www.nsa.gov)
 #### Editors:
 
 Duncan Sparrell (duncan@sfractal.com), [sFractal Consulting
-LLC](http://www.sfractal.com/)
-
-Toby Considine (toby.considine@unc.edu), [University of North Carolina at Chapel Hill](https://www.unc.edu/)
+LLC](http://www.sfractal.com/)\
+Toby Considine (toby.considine@unc.edu), [University of North Carolina at Chapel Hill](https://www.unc.edu/)\
+Jason Romano, [National Security Agency](https://www.nsa.gov/) \
 
 #### Abstract:
 


### PR DESCRIPTION
Per Toby's statement that OASIS prefers to recognize past contributions, this PR puts Jason Romano back in the list of editors.