### PR TITLE
add key / link to Process def'n

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1451,14 +1451,14 @@ the IP address and the prefix, each in their own field.
 
 **Type: Process (Map{1..\*})**
 
-| ID  | Name             | Type           | \#   | Description                                                                          |
-| --- | ---------------- | -------------- | ---- | ------------------------------------------------------------------------------------ |
-| 1   | **pid**          | Integer{0..\*} | 0..1 | Process ID of the process                                                            |
-| 2   | **name**         | String         | 0..1 | Name of the process                                                                  |
-| 3   | **cwd**          | String         | 0..1 | Current working directory of the process                                             |
-| 4   | **executable**   | File           | 0..1 | Executable that was executed to start the process                                    |
-| 5   | **parent**       | Process        | 0..1 | Process that spawned this one                                                        |
-| 6   | **command_line** | String         | 0..1 | The full command line invocation used to start this process, including all arguments |
+| ID  | Name             | Type                         | \#   | Description                                                                 |
+| --- | ---------------- | --------------------- | ---- | ---------------------------------------------------------------------------------- |
+| 1   | **pid**          | Key(Integer{0..\*}) | 0..1 | Process ID of the process                                                            |
+| 2   | **name**         | String              | 0..1 | Name of the process                                                                  |
+| 3   | **cwd**          | String              | 0..1 | Current working directory of the process                                             |
+| 4   | **executable**   | File                | 0..1 | Executable that was executed to start the process                                    |
+| 5   | **parent**       | Link(Process)       | 0..1 | Process that spawned this one                                                        |
+| 6   | **command_line** | String              | 0..1 | The full command line invocation used to start this process, including all arguments |
 
 **Usage Requirement:**
 


### PR DESCRIPTION
This fixes the non-JADN compliant recursion in the Process type (section 3.1.4.15), addressing Issue #413  

This is _document-text-only_ fix; the JADN schema for the Language needs to be updated for a proper fix.