### PR TITLE
Remove limit from feature list

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -1325,9 +1325,9 @@ specified for serializations other than JSON.
 
 #### 3.4.1.5 Features
 
-| Type Name    | Type Definition | \#    | Description                                                                            |
-| ------------ | --------------- | ----- | -------------------------------------------------------------------------------------- |
-| **Features** | Feature unique  | 0..10 | An array of zero to ten names used to query a Consumer for its supported capabilities. |
+| Type Name    | Type Definition | \#    | Description                                                                        |
+| ------------ | --------------- |-------|------------------------------------------------------------------------------------|
+| **Features** | Feature unique  | 0..\* | An array of feature names used to query a Consumer for its supported capabilities. |
 
 
 **Usage Requirements:**


### PR DESCRIPTION
List of features to query must be "unique".  Remove upper bound of 10 since it is arbitrary and unnecessary.