### PR TITLE
fix link to namespace registry

### DIFF
--- a/oc2ls.md
+++ b/oc2ls.md
@@ -996,7 +996,7 @@ The Command defines an Action to be performed on a Target.
 
 #### 3.3.1.3 Profile
 
-OpenC2 maintains an [administrative document](https://github.com/oasis-tcs/openc2-oc2arch/blob/working/namespace-registry.md)
+OpenC2 maintains an [administrative document](https://github.com/oasis-tcs/openc2-oc2arch/blob/published/namespace-registry.md)
 listing current, planned, and extension actuator profile information.
 
 **Type: Profile (Enumerated)**


### PR DESCRIPTION
The namespace registry document was moved from the Architecture repo working branch to the published branch. This PR updates the link in LS section 3.3.1.3.